### PR TITLE
test(core): CI + deepen cover-art core coverage (W7)

### DIFF
--- a/.claude/commands/verify-build.md
+++ b/.claude/commands/verify-build.md
@@ -1,0 +1,51 @@
+# Verify Build Command
+
+Run the cover-art test harness to confirm the core pipeline is green before
+committing or opening a PR.
+
+## Usage
+
+```
+/verify-build
+```
+
+## Instructions
+
+When this command is invoked, run the deterministic test harness for the
+foundation core. Both steps must pass.
+
+1. **Run the full test suite:**
+
+   ```bash
+   python -m pytest tests/ -q
+   ```
+
+   Expect every test to pass. The fixtures synthesize real MP3/M4A/FLAC streams
+   with the bundled ffmpeg from `static-ffmpeg`; the first run may download the
+   ffmpeg/ffprobe binaries.
+
+2. **Run the standalone round-trip smoke check:**
+
+   ```bash
+   python tests/cover_roundtrip_check.py
+   ```
+
+   This embeds a cover into one file per format and confirms ffprobe (the engine
+   Jellyfin uses) reports a cover stream with real, non-zero dimensions. It
+   prints a per-format line and a final `PASS`/`FAIL`, exiting `0` on PASS.
+
+## Report
+
+Summarize the outcome:
+
+- Number of tests passed/failed from pytest.
+- The final `PASS`/`FAIL` line from the round-trip check.
+- If anything fails, surface the first failing assertion and the file it came
+  from. Do not "fix" by weakening an assertion; investigate the core change.
+
+## Why This Matters
+
+The toolkit previously embedded invalid cover art (ffprobe reported
+`width=0, height=0`) with no validation. This harness is the guardrail that
+proves every embed produces art a real consumer can read. Run it whenever the
+cover-art core, ffprobe helpers, or audio-file helpers change.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      # The first ffprobe/ffmpeg call downloads the bundled binaries via the
+      # static-ffmpeg package. Pre-fetch them so the cover-art round-trip tests
+      # exercise the real ffprobe ground-truth path (and to surface any download
+      # issue as its own step rather than a confusing test failure).
+      - name: Pre-fetch ffmpeg/ffprobe (static-ffmpeg)
+        run: python -c "from static_ffmpeg import run; run.get_or_fetch_platform_executables_else_raise()"
+
+      - name: Run test suite
+        run: python -m pytest tests/ -q

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+# Development/test dependencies for the Music Metadata Toolkit.
+# Install the runtime deps first:  pip install -r requirements.txt
+# Then the dev deps:               pip install -r requirements-dev.txt
+#
+# The test fixtures synthesize real MP3/M4A/FLAC streams with the bundled
+# ffmpeg/ffprobe from static-ffmpeg (a runtime dependency, downloaded on first
+# use), so no extra audio tooling is required here.
+pytest>=8.0
+pytest-cov>=5.0

--- a/tests/test_core_extra.py
+++ b/tests/test_core_extra.py
@@ -1,0 +1,150 @@
+"""Deterministic coverage of utilities/core beyond the round-trip happy path.
+
+These tests deepen the foundation harness: magic-byte detection, the
+:func:`validate_image` size policy (reject below MIN_DIMENSION, warn-but-pass
+between MIN_DIMENSION and RECOMMENDED_DIMENSION), the ffprobe "no cover" case,
+and the batch fail-soft accounting in :func:`embed_in_album`.
+
+Helpers are reused from tests/synth.py (imported, never modified).
+"""
+
+import pytest
+
+from tests.synth import make_audio, make_image_bytes
+from utilities.core import cover_art
+from utilities.core.cover_art import (
+    MIN_DIMENSION,
+    RECOMMENDED_DIMENSION,
+    InvalidCoverArt,
+)
+from utilities.core.ffprobe import attached_pic_dims, ffprobe_available
+
+
+# --------------------------------------------------------------------------- #
+# detect_image_mime
+# --------------------------------------------------------------------------- #
+
+
+def test_detect_image_mime_jpeg():
+    assert cover_art.detect_image_mime(make_image_bytes("JPEG")) == "image/jpeg"
+
+
+def test_detect_image_mime_png():
+    assert cover_art.detect_image_mime(make_image_bytes("PNG")) == "image/png"
+
+
+def test_detect_image_mime_empty_is_none():
+    assert cover_art.detect_image_mime(b"") is None
+
+
+def test_detect_image_mime_short_input_is_none():
+    # Shorter than the PNG magic and not a JPEG header: must not index out of range.
+    assert cover_art.detect_image_mime(b"\x89PNG") is None
+    assert cover_art.detect_image_mime(b"\xff") is None
+
+
+def test_detect_image_mime_non_image_is_none():
+    assert cover_art.detect_image_mime(b"<!DOCTYPE html>") is None
+
+
+# --------------------------------------------------------------------------- #
+# validate_image size policy
+# --------------------------------------------------------------------------- #
+
+
+def test_validate_image_low_res_passes_but_warns():
+    # >= MIN_DIMENSION but < RECOMMENDED_DIMENSION: valid art, low-quality warning.
+    low = make_image_bytes("PNG", size=(100, 100))
+    assert cover_art.validate_image(low) == "image/png"
+    warning = cover_art.quality_warning(low)
+    assert warning is not None
+    assert "low-resolution" in warning
+
+
+def test_validate_image_at_min_dimension_boundary_passes():
+    edge = make_image_bytes("PNG", size=(MIN_DIMENSION, MIN_DIMENSION))
+    assert cover_art.validate_image(edge) == "image/png"
+
+
+def test_validate_image_below_min_dimension_rejected():
+    # Between 1 and MIN_DIMENSION - 1 px: a real, decodable image that is still
+    # too small to be album art.
+    tiny = make_image_bytes("PNG", size=(MIN_DIMENSION - 1, MIN_DIMENSION - 1))
+    with pytest.raises(InvalidCoverArt):
+        cover_art.validate_image(tiny)
+
+
+def test_validate_image_non_image_rejected():
+    with pytest.raises(InvalidCoverArt):
+        cover_art.validate_image(b"this is plainly not an image")
+
+
+def test_validate_image_empty_rejected():
+    with pytest.raises(InvalidCoverArt):
+        cover_art.validate_image(b"")
+
+
+def test_quality_warning_none_for_recommended_size():
+    big = make_image_bytes("JPEG", size=(RECOMMENDED_DIMENSION, RECOMMENDED_DIMENSION))
+    assert cover_art.quality_warning(big) is None
+
+
+# --------------------------------------------------------------------------- #
+# ffprobe.attached_pic_dims
+# --------------------------------------------------------------------------- #
+
+
+def test_attached_pic_dims_none_when_no_cover(tmp_path):
+    # A freshly synthesized audio file has no embedded cover stream, so ffprobe
+    # (or the no-ffprobe fallback) must report None rather than (0, 0).
+    path = make_audio(tmp_path / "no_cover.mp3", "libmp3lame")
+    assert attached_pic_dims(path) is None
+
+
+# --------------------------------------------------------------------------- #
+# embed_in_album fail-soft accounting
+# --------------------------------------------------------------------------- #
+
+
+def test_embed_in_album_counts_failures_and_continues(tmp_path):
+    # One genuine audio file plus one file with an audio extension but junk
+    # content: the junk file fails to embed and is logged, the good one succeeds.
+    make_audio(tmp_path / "good.mp3", "libmp3lame")
+    (tmp_path / "broken.flac").write_bytes(b"not a real flac stream")
+
+    result = cover_art.embed_in_album(tmp_path, make_image_bytes("JPEG"))
+
+    assert result["total"] == 2
+    assert result["embedded"] == 1
+    assert result["failed"] == 1
+    assert len(result["errors"]) == 1
+    assert "broken.flac" in result["errors"][0]
+    # folder.jpg is written because at least one file embedded successfully.
+    assert (tmp_path / "folder.jpg").exists()
+
+
+def test_embed_in_album_no_folder_jpg_when_all_fail(tmp_path):
+    (tmp_path / "broken.mp3").write_bytes(b"junk bytes, not mp3")
+    result = cover_art.embed_in_album(tmp_path, make_image_bytes("JPEG"))
+    assert result["total"] == 1
+    assert result["embedded"] == 0
+    assert result["failed"] == 1
+    assert not (tmp_path / "folder.jpg").exists()
+
+
+# --------------------------------------------------------------------------- #
+# PNG round-trip with ffprobe ground truth
+# --------------------------------------------------------------------------- #
+
+
+def test_png_cover_roundtrip_ffprobe_dims(tmp_path):
+    path = make_audio(tmp_path / "track.mp3", "libmp3lame")
+    data = make_image_bytes("PNG", size=(640, 640))
+    cover_art.embed_in_file(path, data)
+
+    if ffprobe_available():
+        dims = attached_pic_dims(path)
+        assert dims is not None
+        assert dims[0] > 0 and dims[1] > 0
+
+    assert cover_art.extract_cover_from_file(path) == data


### PR DESCRIPTION
## Summary
W7 unit: add CI and broaden deterministic test coverage of the foundation cover-art core. No production code touched.

## Changes
- **tests/test_core_extra.py** (new, 15 tests): `detect_image_mime` on JPEG/PNG/empty/short/non-image input; `validate_image` size policy (low-res warn-but-pass, MIN_DIMENSION boundary passes, below-min rejects, non-image/empty reject); `quality_warning` None at recommended size; `attached_pic_dims` returns None for a file with no cover; `embed_in_album` fail-soft counts (failures logged, good files continue, folder.jpg only when at least one embed succeeds); PNG cover round-trip asserting ffprobe dims > 0. Reuses helpers from tests/synth.py.
- **.github/workflows/ci.yml** (new): on push/PR, Python 3.13, installs `requirements.txt` + `requirements-dev.txt`, pre-fetches static-ffmpeg binaries so the ffprobe assertions run, then `python -m pytest tests/ -q`.
- **requirements-dev.txt** (new): pytest, pytest-cov (with a note to install requirements.txt first).
- **.claude/commands/verify-build.md** (new): command doc that runs `python -m pytest tests/ -q` and `python tests/cover_roundtrip_check.py`.

## Verification
- `python -m pytest tests/ -q` -> 39 passed (24 foundation + 15 new).
- `python tests/cover_roundtrip_check.py` -> PASS (mp3/m4a/flac, ffprobe dims 640x640).
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` -> parses OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWhdpZqWE7QNtTFYYS3Z3T