### PR TITLE
feat: pluggable AI cover-match validator framework (W5)

### DIFF
--- a/.claude/commands/ai-validate-covers.md
+++ b/.claude/commands/ai-validate-covers.md
@@ -1,0 +1,61 @@
+# AI Validate Covers Command
+
+Run the OPTIONAL AI "second opinion" pass over embedded album cover art to flag
+art that is technically valid but visually WRONG for the album.
+
+## Usage
+
+```
+/ai-validate-covers <path>
+```
+
+## Examples
+
+```
+/ai-validate-covers /path/to/music/Various Artists
+/ai-validate-covers D:/music/Ben Harper
+```
+
+## Instructions
+
+When this command is invoked with a path argument: $ARGUMENTS
+
+**Path Normalization:**
+Replace all backslashes (`\`) with forward slashes (`/`).
+
+**Execute the validation pass (NON-DESTRUCTIVE - never deletes or replaces art):**
+
+1. **Run the validator** over the path:
+   ```bash
+   cd "D:\music cleanup" && python utilities/ai_validate_covers.py "<normalized_path>"
+   ```
+
+2. **Behavior depends on `ai_validation` in `music-config.yaml`:**
+   - Default (`enabled: false` / `provider: null`): the `NullValidator` runs,
+     every album abstains, and NO network calls are made. This is the safe,
+     zero-AI default.
+   - If a provider is configured (ollama, openai_compat, anthropic, hermes, or a
+     contrib validator), that validator judges each album's art.
+
+3. **High-confidence mismatches** (confidence >= 0.80) are logged to
+   `.claude/knowledge/patterns.json` under `ai_cover_mismatches` for review.
+   The command does NOT auto-fix; review and fix manually with `embed_cover.py`.
+
+4. **Report summary** from the command output:
+   - albums, checked, mismatches, abstained, errors
+
+## Provider selection (optional)
+
+To use a specific provider for one run without editing the config:
+
+```bash
+cd "D:\music cleanup" && python utilities/ai_validate_covers.py "<path>" --provider ollama --endpoint http://localhost:11434 --model llava
+```
+
+## Notes
+
+- This layer is OPTIONAL and sits on top of the always-on deterministic cover
+  checks in `utilities/core/`. It adds a visual-match opinion only.
+- `fail_mode: soft` (default) means any AI error is logged and the scan
+  continues. Set `fail_mode: hard` in config to re-raise.
+- See `docs/AI_VALIDATORS.md` to bring your own validator.

--- a/README.md
+++ b/README.md
@@ -314,6 +314,48 @@ python utilities/embed_cover.py "path/to/album" "https://cover-url.jpg"
 
 See [`docs/standalone-usage.md`](docs/standalone-usage.md) for a comprehensive standalone usage guide.
 
+## Bring Your Own Validator (optional AI second opinion)
+
+The deterministic cover checks in `utilities/core/` (Pillow + ffprobe) are
+always-on and need no AI and no network. On top of them sits an **optional,
+pluggable** AI layer that gives a "second opinion" on whether embedded album art
+visually matches the album (catching art that is technically valid but wrong).
+
+By default this layer is OFF and requires nothing:
+
+```yaml
+# music-config.yaml
+ai_validation:
+  enabled: false      # NullValidator: abstains on every album, zero network calls
+  provider: null
+```
+
+Run a pass (default config runs the NullValidator with no AI and no network):
+
+```bash
+python utilities/ai_validate_covers.py "/path/to/music/Artist"
+```
+
+Owners can wire in their own validator (e.g. a local Hermes/Jarvis gateway) and
+the public can bring **Ollama**, an **OpenAI-compatible** server, **Anthropic
+Claude**, a custom **Hermes** gateway, or nothing at all. Selecting a provider:
+
+```yaml
+ai_validation:
+  enabled: true
+  provider: ollama            # or openai_compat | anthropic | hermes | <your contrib name>
+  endpoint: "http://localhost:11434"
+  model: "llava"
+```
+
+To add a validator without touching the toolkit, drop a `BaseAIValidator`
+subclass in `validators/contrib/` (copy `validators/contrib/example_validator.py`)
+or register an entry point in the `music_toolkit.validators` group. The pass is
+non-destructive: high-confidence mismatches are logged to
+`.claude/knowledge/patterns.json` for review, never auto-fixed.
+
+See [`docs/AI_VALIDATORS.md`](docs/AI_VALIDATORS.md) for the full guide.
+
 ## Resources
 
 - [MusicBrainz](https://musicbrainz.org/) - Music metadata database

--- a/configs/templates/credentials.yaml.example
+++ b/configs/templates/credentials.yaml.example
@@ -19,3 +19,26 @@ musicbrainz:
   user_agent: "MusicCleanup/1.0 (your@email.com)"
 
 # Note: iTunes Search API requires no credentials
+
+# ---------------------------------------------------------------------------
+# AI cover-art validators (OPTIONAL second-opinion layer)
+# ---------------------------------------------------------------------------
+# Only needed if you enable ai_validation in music-config.yaml AND pick a
+# provider that requires a key/endpoint. The default (provider: null) needs
+# nothing here. Keys can also be supplied via environment variables instead of
+# this file - see docs/AI_VALIDATORS.md.
+
+# Anthropic (Claude vision) - cloud. Env fallback: ANTHROPIC_API_KEY
+anthropic:
+  api_key: "YOUR_ANTHROPIC_API_KEY"
+
+# OpenAI-compatible servers (LM Studio / vLLM / OpenRouter / OpenAI).
+# Optional for local servers. Env fallback: OPENAI_API_KEY
+openai_compat:
+  api_key: "YOUR_OPENAI_COMPATIBLE_API_KEY"
+
+# Hermes/Jarvis-style gateway - bearer token, optional. Env fallback: HERMES_API_KEY
+hermes:
+  api_key: "YOUR_HERMES_GATEWAY_TOKEN"
+
+# Ollama (local llava etc.) requires no key.

--- a/docs/AI_VALIDATORS.md
+++ b/docs/AI_VALIDATORS.md
@@ -1,0 +1,149 @@
+# AI Cover-Art Validators (optional second opinion)
+
+The deterministic cover checks in `utilities/core/` (Pillow + ffprobe) are
+**always-on** and require no AI and no network. They guarantee that embedded art
+is a real, decodable image with valid dimensions.
+
+What they cannot tell you is whether the art is the *correct* cover for the
+album (the "Ben Harper problem": a technically-valid image that visually belongs
+to a different album). That is what this OPTIONAL, pluggable AI layer adds: a
+configurable "second opinion" that looks at the art and the album metadata and
+returns a verdict.
+
+## Zero-AI by default
+
+Out of the box the toolkit ships with AI validation **off**:
+
+```yaml
+# music-config.yaml
+ai_validation:
+  enabled: false
+  provider: null
+```
+
+With this default, `python utilities/ai_validate_covers.py <album>` runs the
+`NullValidator`, which abstains on every album and makes **zero network calls**.
+You never need an AI key or an internet connection to use the toolkit.
+
+## Running a pass
+
+```bash
+# Default (NullValidator) - scans, extracts art via core, reports abstain
+python utilities/ai_validate_covers.py "/path/to/music/Artist"
+
+# Pick a provider for this run only
+python utilities/ai_validate_covers.py "/path/to/album" --provider ollama --endpoint http://localhost:11434 --model llava
+
+# Force-enable whatever provider is configured in music-config.yaml
+python utilities/ai_validate_covers.py "/path/to/music/Artist" --enable
+```
+
+The CLI is **non-destructive**. On a high-confidence `mismatch` (confidence
+>= 0.80) it appends a note to `.claude/knowledge/patterns.json` under
+`ai_cover_mismatches` for a human to review. It never deletes or replaces art.
+
+`fail_mode: soft` (the default) logs any validator/network error and continues;
+`fail_mode: hard` re-raises.
+
+## The verdict contract
+
+Every validator returns a `Verdict`:
+
+| Field        | Meaning                                                              |
+| ------------ | ------------------------------------------------------------------- |
+| `verdict`    | `match` / `mismatch` / `uncertain` / `abstain`                      |
+| `confidence` | 0.0 - 1.0 (treat `abstain` as 0.0)                                  |
+| `notes`      | short human-readable explanation                                    |
+| `provider`   | which validator produced it                                         |
+
+`abstain` means "I did not / could not judge" - the default, the null provider,
+any non-vision provider, and any soft error all abstain.
+
+## Built-in providers
+
+| `provider`       | Backend                                  | Needs                                  |
+| ---------------- | ---------------------------------------- | -------------------------------------- |
+| `null`           | none (default)                           | nothing                                |
+| `ollama`         | local Ollama vision model (e.g. `llava`) | Ollama running locally                 |
+| `openai_compat`  | LM Studio / vLLM / OpenRouter / OpenAI   | endpoint (+ key for cloud)             |
+| `anthropic`      | Claude vision (Messages API)             | `ANTHROPIC_API_KEY`                    |
+| `hermes`         | a configurable Hermes/Jarvis gateway     | your gateway `endpoint`                |
+
+Example config for a local Ollama vision model (fully local, private):
+
+```yaml
+ai_validation:
+  enabled: true
+  provider: ollama
+  endpoint: "http://localhost:11434"
+  model: "llava"
+```
+
+API keys can come from `configs/active/credentials.yaml` (see
+`configs/templates/credentials.yaml.example`) or from environment variables
+(`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `HERMES_API_KEY`).
+
+## Bring your own validator
+
+There are two ways to add a validator without touching the toolkit's code.
+
+### 1. Drop a file in `validators/contrib/`
+
+Copy `validators/contrib/example_validator.py` and edit it. The registry
+auto-discovers any `BaseAIValidator` subclass in that folder and makes it
+selectable by its `name`:
+
+```python
+# validators/contrib/my_validator.py
+from typing import Any, Dict
+from validators.base import BaseAIValidator, Verdict
+
+class MyValidator(BaseAIValidator):
+    name = "my-validator"  # what you put in ai_validation.provider
+
+    @property
+    def capabilities(self) -> Dict[str, bool]:
+        return {"vision": True}
+
+    def verify_cover_match(self, image_bytes: bytes, album_meta: Dict[str, Any]) -> Verdict:
+        # import any network library lazily, inside the method
+        # call your model/service, then translate its answer:
+        return Verdict(verdict="match", confidence=0.9, notes="...", provider=self.name)
+```
+
+```yaml
+ai_validation:
+  enabled: true
+  provider: my-validator
+```
+
+### 2. Register a pip-installable entry point
+
+In your own package's `pyproject.toml`:
+
+```toml
+[project.entry-points."music_toolkit.validators"]
+my-validator = "my_package.module:MyValidator"
+```
+
+After `pip install`, select it the same way (`provider: my-validator`).
+
+### Rules every validator must follow
+
+1. Subclass `BaseAIValidator` and set a unique `name`.
+2. Declare `capabilities` - at least `{"vision": bool}`. A non-vision provider
+   must `abstain`.
+3. Implement `verify_cover_match(image_bytes, album_meta) -> Verdict`.
+4. **Never raise for an expected failure** (missing key/endpoint, network down,
+   model refusal). Return an `abstain` verdict (use `self._abstain("...")`) so
+   the caller can fail soft.
+5. Import network libraries lazily inside methods, never at module top level -
+   importing the `validators` package must not require `requests` or any SDK.
+
+## Listing what is available
+
+```python
+from validators import available_validators
+print(available_validators())
+# {'null': 'builtin', 'ollama': 'builtin', ..., 'example': 'contrib', ...}
+```

--- a/music-config.yaml
+++ b/music-config.yaml
@@ -80,6 +80,22 @@ cover_art:
   also_save_folder_jpg: true
   folder_jpg_name: "folder.jpg"
 
+# Optional AI "second opinion" on cover art (visual cover-match).
+# The deterministic cover checks in utilities/core/ are always-on and do NOT
+# depend on this block. This is an OPTIONAL, pluggable layer. The default is
+# zero-AI and zero-network: enabled: false + provider: null (NullValidator),
+# which abstains on every album and never touches the network.
+# See docs/AI_VALIDATORS.md to bring your own validator.
+ai_validation:
+  enabled: false             # master switch; false = NullValidator (no AI, no network)
+  provider: null             # null | ollama | openai_compat | anthropic | hermes | <contrib name>
+  endpoint: ""               # provider URL (e.g. http://localhost:11434 for ollama)
+  model: ""                  # vision model name (provider-specific default if blank)
+  checks:
+    cover_visual_match: true # ask the validator whether art matches the album
+  fail_mode: soft            # soft = log AI errors and continue; hard = re-raise
+  timeout: 60                # seconds per request
+
 # Multi-disc handling
 multi_disc:
   consolidate: true

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,120 @@
+"""Tests for the pluggable AI validator framework.
+
+These assert the zero-AI default contract: NullValidator abstains, the registry
+resolves names (including the contrib template) without any network, and bad
+names degrade to abstain rather than raising.
+"""
+
+import pytest
+
+from validators import (
+    BaseAIValidator,
+    NullValidator,
+    Verdict,
+    available_validators,
+    get_validator,
+)
+
+ALBUM_META = {"album": "Achtung Baby", "artist": "U2", "year": "1991"}
+FAKE_IMAGE = b"\xff\xd8\xff" + b"\x00" * 64  # non-empty; validators don't decode it
+
+
+def test_verdict_rejects_bad_label():
+    with pytest.raises(ValueError):
+        Verdict(verdict="definitely")
+
+
+def test_verdict_clamps_confidence():
+    assert Verdict(verdict="match", confidence=5.0).confidence == 1.0
+    assert Verdict(verdict="match", confidence=-1.0).confidence == 0.0
+
+
+def test_null_validator_abstains():
+    validator = NullValidator({})
+    assert validator.name == "null"
+    assert validator.capabilities == {"vision": False}
+    verdict = validator.verify_cover_match(FAKE_IMAGE, ALBUM_META)
+    assert verdict.abstained
+    assert verdict.verdict == "abstain"
+    assert verdict.confidence == 0.0
+    assert verdict.provider == "null"
+
+
+def test_get_validator_default_is_null():
+    # Missing, empty, and "null" all resolve to NullValidator.
+    for name in (None, "", "null"):
+        validator = get_validator(name, {})
+        assert isinstance(validator, NullValidator)
+
+
+def test_get_validator_unknown_name_degrades_to_null():
+    validator = get_validator("does-not-exist", {})
+    assert isinstance(validator, NullValidator)
+    assert validator.verify_cover_match(FAKE_IMAGE, ALBUM_META).abstained
+
+
+def test_registry_loads_contrib_example_by_name():
+    validator = get_validator("example", {})
+    assert isinstance(validator, BaseAIValidator)
+    assert validator.name == "example"
+    verdict = validator.verify_cover_match(FAKE_IMAGE, ALBUM_META)
+    assert isinstance(verdict, Verdict)
+    assert verdict.verdict in {"match", "mismatch", "uncertain", "abstain"}
+    assert verdict.provider == "example"
+    # The template received the bytes and referenced the album in its notes.
+    assert "Achtung Baby" in verdict.notes
+
+
+def test_contrib_example_abstains_on_empty_image():
+    validator = get_validator("example", {})
+    assert validator.verify_cover_match(b"", ALBUM_META).abstained
+
+
+def test_available_validators_lists_builtins_and_contrib():
+    found = available_validators()
+    for builtin in ("null", "ollama", "openai_compat", "anthropic", "hermes"):
+        assert found.get(builtin) == "builtin"
+    assert found.get("example") == "contrib"
+
+
+def test_parse_verdict_extracts_json_with_trailing_prose():
+    from validators._prompt import parse_verdict
+
+    text = '{"verdict": "mismatch", "confidence": 0.95, "notes": "wrong band"}. Note: {n/a}'
+    verdict = parse_verdict(text, "test")
+    assert verdict.verdict == "mismatch"
+    assert verdict.confidence == 0.95
+
+
+def test_parse_verdict_does_not_misread_negation():
+    from validators._prompt import parse_verdict
+
+    # Prose answer with no JSON: must NOT be classified as mismatch/match by
+    # naive substring scanning; stays conservative as uncertain.
+    for prose in (
+        "The artwork is correct; there is no mismatch with this album.",
+        "This is not a match for the album.",
+    ):
+        verdict = parse_verdict(prose, "test")
+        assert verdict.verdict == "uncertain"
+
+
+def test_parse_verdict_handles_non_string_content():
+    from validators._prompt import parse_verdict
+
+    # List-of-parts (some OpenAI-compatible servers) must not raise.
+    verdict = parse_verdict([{"type": "text", "text": "x"}], "test")
+    assert verdict.verdict in {"uncertain", "abstain"}
+    assert parse_verdict(None, "test").abstained
+
+
+def test_builtin_vision_validators_abstain_without_endpoint_or_key(monkeypatch):
+    # Even with the providers selected, no endpoint/key means fail-soft abstain,
+    # and crucially no network call is attempted (empty image short-circuits or
+    # the missing-config guards return abstain first).
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("HERMES_API_KEY", raising=False)
+    for name in ("anthropic", "hermes"):
+        validator = get_validator(name, {"endpoint": "", "model": ""})
+        verdict = validator.verify_cover_match(b"", ALBUM_META)
+        assert verdict.abstained

--- a/utilities/ai_validate_covers.py
+++ b/utilities/ai_validate_covers.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Optional AI second-opinion pass over embedded album cover art.
+
+Scans a folder of albums, pulls the embedded cover bytes out of each album via
+the always-on core pipeline (``utilities/core/cover_art.py``), and asks the
+configured AI validator whether the art visually matches the album.
+
+This is purely advisory and NON-DESTRUCTIVE: on a high-confidence ``mismatch``
+it records a note in ``.claude/knowledge/patterns.json`` for a human to review.
+It NEVER deletes or replaces art.
+
+Defaults are zero-AI and zero-network: with the shipped ``music-config.yaml``
+(``ai_validation.enabled: false`` / ``provider: null``) this runs the
+:class:`~validators.null.NullValidator`, which abstains on every album and
+makes no network calls.
+
+Usage:
+    python utilities/ai_validate_covers.py "/path/to/music/Artist"
+    python utilities/ai_validate_covers.py "/path/to/album" --provider ollama
+    python utilities/ai_validate_covers.py "/path/to/music/Artist" --config music-config.yaml
+
+``fail_mode: soft`` (the default) means any AI/validator error is logged and the
+scan continues; ``hard`` re-raises.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Make the project root importable when run as a script.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from utilities.core.audio_file import iter_audio_files  # read-only core import
+from utilities.core.cover_art import extract_cover_from_file  # read-only core import
+from validators import Verdict, get_validator
+
+DEFAULT_CONFIG_PATH = _PROJECT_ROOT / "music-config.yaml"
+KNOWLEDGE_PATH = _PROJECT_ROOT / ".claude" / "knowledge" / "patterns.json"
+
+# Below this we treat a verdict as advisory only and do not log it.
+MISMATCH_LOG_THRESHOLD = 0.80
+
+DEFAULT_AI_CONFIG: Dict[str, Any] = {
+    "enabled": False,
+    "provider": "null",
+    "endpoint": "",
+    "model": "",
+    "checks": {"cover_visual_match": True},
+    "fail_mode": "soft",
+    "timeout": 60,
+}
+
+
+def load_ai_config(config_path: Optional[Path]) -> Dict[str, Any]:
+    """Load the ``ai_validation`` block from a YAML config, with safe defaults."""
+    config = dict(DEFAULT_AI_CONFIG)
+    if not config_path or not config_path.exists():
+        return config
+    try:
+        import yaml  # optional dependency
+    except ImportError:
+        print("  (pyyaml not installed; using built-in AI defaults: disabled/null)")
+        return config
+    try:
+        with open(config_path, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+    except Exception as exc:
+        print(f"  (could not read {config_path}: {exc}; using AI defaults)")
+        return config
+    block = data.get("ai_validation")
+    if isinstance(block, dict):
+        config.update(block)
+    return config
+
+
+def read_album_meta(album_path: Path) -> Dict[str, Any]:
+    """Read minimal album metadata (album, artist, year) from the first track."""
+    meta: Dict[str, Any] = {"album": album_path.name, "artist": "", "year": ""}
+    for audio_file in iter_audio_files(album_path):
+        try:
+            from mutagen import File as MutagenFile
+
+            audio = MutagenFile(str(audio_file), easy=True)
+        except Exception:
+            break
+        if not audio:
+            break
+        tags = getattr(audio, "tags", None) or {}
+
+        def first(*keys: str) -> str:
+            for key in keys:
+                value = tags.get(key)
+                if value:
+                    return str(value[0]) if isinstance(value, list) else str(value)
+            return ""
+
+        meta["album"] = first("album") or meta["album"]
+        meta["artist"] = first("albumartist", "artist") or meta["artist"]
+        meta["year"] = first("date", "year")
+        break
+    return meta
+
+
+def find_albums(root: Path) -> List[Path]:
+    """Return album folders under ``root``.
+
+    If ``root`` itself contains audio files, it is treated as a single album.
+    Otherwise every immediate subdirectory that contains audio is an album.
+    """
+    if any(iter_audio_files(root)):
+        return [root]
+    albums = []
+    for entry in sorted(root.iterdir()):
+        if entry.is_dir() and any(iter_audio_files(entry)):
+            albums.append(entry)
+    return albums
+
+
+def extract_album_cover(album_path: Path) -> Optional[bytes]:
+    """Return embedded cover bytes from the first track that has art."""
+    for audio_file in iter_audio_files(album_path):
+        data = extract_cover_from_file(audio_file)
+        if data:
+            return data
+    return None
+
+
+def log_mismatch(album_path: Path, meta: Dict[str, Any], verdict: Verdict) -> None:
+    """Append a non-destructive mismatch note to the knowledge base."""
+    KNOWLEDGE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    store: Dict[str, Any] = {}
+    if KNOWLEDGE_PATH.exists():
+        try:
+            with open(KNOWLEDGE_PATH, "r", encoding="utf-8") as handle:
+                store = json.load(handle) or {}
+        except (ValueError, OSError):
+            store = {}
+    if not isinstance(store, dict):
+        # An unexpected top-level shape (e.g. a JSON list) must not crash the
+        # scan; preserve the original payload and write our notes alongside it.
+        store = {"_original": store}
+
+    entries = store.setdefault("ai_cover_mismatches", [])
+    entries.append(
+        {
+            "album_path": str(album_path),
+            "album": meta.get("album"),
+            "artist": meta.get("artist"),
+            "verdict": verdict.verdict,
+            "confidence": verdict.confidence,
+            "notes": verdict.notes,
+            "provider": verdict.provider,
+            "detected_at": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+    with open(KNOWLEDGE_PATH, "w", encoding="utf-8") as handle:
+        json.dump(store, handle, indent=2)
+
+
+def validate_path(path: Path, ai_config: Dict[str, Any]) -> Dict[str, int]:
+    """Run the configured validator over every album under ``path``."""
+    fail_mode = str(ai_config.get("fail_mode", "soft")).lower()
+    checks = ai_config.get("checks") or {}
+    enabled = bool(ai_config.get("enabled", False))
+    provider = ai_config.get("provider") if enabled else "null"
+
+    if not enabled:
+        print("AI validation is disabled (ai_validation.enabled: false).")
+        print("Running with NullValidator: every album will abstain, no network calls.")
+    if not checks.get("cover_visual_match", True):
+        print("cover_visual_match check is disabled; nothing to do.")
+        return {"albums": 0, "checked": 0, "mismatches": 0, "abstained": 0, "errors": 0}
+
+    validator = get_validator(provider, ai_config)
+    print(f"Validator: {validator.name} (vision={validator.capabilities.get('vision')})")
+
+    stats = {"albums": 0, "checked": 0, "mismatches": 0, "abstained": 0, "errors": 0}
+    albums = find_albums(path)
+    stats["albums"] = len(albums)
+
+    for album in albums:
+        cover = extract_album_cover(album)
+        if not cover:
+            print(f"  [skip] {album.name}: no embedded cover art")
+            continue
+        meta = read_album_meta(album)
+        stats["checked"] += 1
+        try:
+            verdict = validator.verify_cover_match(cover, meta)
+        except Exception as exc:
+            stats["errors"] += 1
+            print(f"  [error] {album.name}: {exc}")
+            if fail_mode == "hard":
+                raise
+            continue
+
+        if verdict.abstained:
+            stats["abstained"] += 1
+            print(f"  [abstain] {album.name}: {verdict.notes}")
+        elif verdict.is_mismatch and verdict.confidence >= MISMATCH_LOG_THRESHOLD:
+            stats["mismatches"] += 1
+            print(
+                f"  [MISMATCH] {album.name}: {verdict.confidence:.2f} - {verdict.notes}"
+            )
+            log_mismatch(album, meta, verdict)
+        else:
+            print(
+                f"  [{verdict.verdict}] {album.name}: "
+                f"{verdict.confidence:.2f} - {verdict.notes}"
+            )
+
+    return stats
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Optional AI second-opinion pass over embedded album cover art."
+    )
+    parser.add_argument("path", help="Album folder or artist folder of albums")
+    parser.add_argument(
+        "--config",
+        default=str(DEFAULT_CONFIG_PATH),
+        help="Path to music-config.yaml (default: project root)",
+    )
+    parser.add_argument("--provider", help="Override ai_validation.provider")
+    parser.add_argument("--endpoint", help="Override ai_validation.endpoint")
+    parser.add_argument("--model", help="Override ai_validation.model")
+    parser.add_argument(
+        "--enable",
+        action="store_true",
+        help="Force-enable AI validation even if config has enabled: false",
+    )
+    args = parser.parse_args(argv)
+
+    target = Path(args.path)
+    if not target.exists():
+        print(f"Path not found: {target}")
+        return 1
+
+    ai_config = load_ai_config(Path(args.config) if args.config else None)
+    if args.enable:
+        ai_config["enabled"] = True
+    if args.provider:
+        ai_config["provider"] = args.provider
+        ai_config["enabled"] = True
+    if args.endpoint:
+        ai_config["endpoint"] = args.endpoint
+    if args.model:
+        ai_config["model"] = args.model
+
+    print(f"Scanning: {target}")
+    stats = validate_path(target, ai_config)
+    print(
+        "\nDone. "
+        f"albums={stats['albums']} checked={stats['checked']} "
+        f"mismatches={stats['mismatches']} abstained={stats['abstained']} "
+        f"errors={stats['errors']}"
+    )
+    if stats["mismatches"]:
+        print(f"Mismatches logged to {KNOWLEDGE_PATH} (no art was modified).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/validators/__init__.py
+++ b/validators/__init__.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Pluggable AI cover-art validators (optional second-opinion layer).
+
+The deterministic cover checks in ``utilities/core/`` are always-on and do not
+depend on anything here. This package adds an OPTIONAL AI "second opinion" on
+whether embedded album art visually matches an album. The DEFAULT
+(:class:`~validators.null.NullValidator`) abstains and makes zero network
+calls, so the public, zero-config experience needs no AI and no internet.
+
+Public API:
+    from validators import get_validator, Verdict, BaseAIValidator
+    v = get_validator("null", {})            # default, always abstains
+    verdict = v.verify_cover_match(b"", {})  # -> Verdict(verdict="abstain", ...)
+
+Bring your own validator via ``validators/contrib/`` or an entry point in the
+``music_toolkit.validators`` group - see ``docs/AI_VALIDATORS.md``.
+"""
+
+from __future__ import annotations
+
+from .base import VERDICTS, BaseAIValidator, Verdict
+from .null import NullValidator
+from .registry import available_validators, get_validator
+
+__all__ = [
+    "BaseAIValidator",
+    "Verdict",
+    "VERDICTS",
+    "NullValidator",
+    "get_validator",
+    "available_validators",
+]

--- a/validators/_prompt.py
+++ b/validators/_prompt.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Shared prompt + response parsing for vision validators.
+
+Kept separate so every provider asks the model the same question and parses the
+answer the same way. No network or SDK imports here.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, Dict
+
+from .base import VERDICTS, Verdict
+
+SYSTEM_PROMPT = (
+    "You are a meticulous music-library assistant. You are shown an album "
+    "cover image and the album's metadata. Decide whether the image is "
+    "plausibly the correct front cover for that album. Be conservative: only "
+    "say 'mismatch' when the artwork clearly belongs to a different album or "
+    "is obviously not album art."
+)
+
+
+def build_user_prompt(album_meta: Dict[str, Any]) -> str:
+    """Build the text portion of the prompt from album metadata."""
+    album = album_meta.get("album") or album_meta.get("title") or "(unknown)"
+    artist = album_meta.get("artist") or album_meta.get("albumartist") or "(unknown)"
+    year = album_meta.get("year") or album_meta.get("date") or ""
+    extra = f" (released {year})" if year else ""
+    return (
+        f"Album: {album}\n"
+        f"Artist: {artist}{extra}\n\n"
+        "Does the attached image look like the correct front cover for this "
+        "album? Respond ONLY with a compact JSON object of the form:\n"
+        '{"verdict": "match|mismatch|uncertain", "confidence": 0.0-1.0, '
+        '"notes": "<short reason>"}'
+    )
+
+
+def encode_image_data_url(image_bytes: bytes) -> str:
+    """Return a base64 ``data:`` URL for OpenAI-style image parts."""
+    b64 = base64.b64encode(image_bytes).decode("ascii")
+    mime = "image/png" if image_bytes[:8] == b"\x89PNG\r\n\x1a\n" else "image/jpeg"
+    return f"data:{mime};base64,{b64}"
+
+
+def encode_image_b64(image_bytes: bytes) -> str:
+    """Return bare base64 (Ollama / Anthropic style)."""
+    return base64.b64encode(image_bytes).decode("ascii")
+
+
+def _first_json_object(text: str) -> Dict[str, Any]:
+    """Return the first valid JSON object embedded in ``text``, or ``{}``.
+
+    Scans each ``{`` and uses a raw decoder so trailing prose after a complete
+    object (e.g. ``{...}. Note: see below``) does not defeat parsing - unlike a
+    greedy ``{.*}`` regex, which spans to the last ``}`` and fails on the inner
+    brace.
+    """
+    decoder = json.JSONDecoder()
+    index = text.find("{")
+    while index != -1:
+        try:
+            obj, _ = decoder.raw_decode(text, index)
+        except ValueError:
+            index = text.find("{", index + 1)
+            continue
+        if isinstance(obj, dict):
+            return obj
+        index = text.find("{", index + 1)
+    return {}
+
+
+def parse_verdict(text: Any, provider: str) -> Verdict:
+    """Parse a model's free-text answer into a :class:`Verdict`.
+
+    Prefers a JSON object embedded in the response (the format we ask for). If
+    no usable verdict can be parsed, returns ``uncertain`` rather than guessing
+    from naive substrings - a prose answer like "there is no mismatch" must not
+    be misread as a mismatch (which would get logged as a false positive). Never
+    raises: a non-string ``text`` is coerced safely.
+    """
+    if not isinstance(text, str):
+        text = "" if text is None else str(text)
+    if not text.strip():
+        return Verdict("abstain", 0.0, "empty model response", provider)
+
+    payload = _first_json_object(text)
+    verdict = str(payload.get("verdict", "")).strip().lower()
+    if verdict not in VERDICTS or verdict == "abstain":
+        # Could not extract a clear verdict; do NOT guess from substrings
+        # (negations like "no mismatch" would invert). Stay conservative.
+        verdict = "uncertain"
+
+    try:
+        confidence = float(payload.get("confidence", 0.5))
+    except (TypeError, ValueError):
+        confidence = 0.5
+
+    notes = str(payload.get("notes") or text.strip())[:300]
+    return Verdict(verdict=verdict, confidence=confidence, notes=notes, provider=provider)

--- a/validators/anthropic.py
+++ b/validators/anthropic.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Cloud-vision validator backed by Anthropic's Claude Messages API.
+
+Uses Claude vision (base64 image blocks) to judge whether embedded cover art
+matches an album. To keep the toolkit's zero-AI default true, this talks to the
+Messages API over raw HTTP via ``requests`` (imported lazily) rather than
+pulling in the ``anthropic`` SDK as a dependency. Any failure - missing key,
+network error, refusal - degrades to an ``abstain`` verdict.
+
+Config keys (from the ``ai_validation`` block):
+  * ``endpoint``: base URL, default ``https://api.anthropic.com``
+  * ``model``: vision-capable model, default ``claude-opus-4-8``
+  * ``api_key``: Anthropic API key. Falls back to the ``ANTHROPIC_API_KEY``
+    environment variable.
+  * ``timeout``: seconds, default 60
+
+Reference: POST {endpoint}/v1/messages with headers ``x-api-key`` and
+``anthropic-version: 2023-06-01``; the image is a base64 ``image`` content block.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from ._prompt import (
+    SYSTEM_PROMPT,
+    build_user_prompt,
+    encode_image_b64,
+    parse_verdict,
+)
+from .base import BaseAIValidator, Verdict
+
+DEFAULT_ENDPOINT = "https://api.anthropic.com"
+DEFAULT_MODEL = "claude-opus-4-8"
+ANTHROPIC_VERSION = "2023-06-01"
+
+
+class AnthropicValidator(BaseAIValidator):
+    """Vision validator using Claude via the Anthropic Messages API."""
+
+    name = "anthropic"
+
+    def __init__(self, config: Dict[str, Any] | None = None):
+        super().__init__(config)
+        self.endpoint = self.endpoint or DEFAULT_ENDPOINT
+        self.model = self.model or DEFAULT_MODEL
+        self.api_key = str(
+            self.config.get("api_key") or os.environ.get("ANTHROPIC_API_KEY") or ""
+        )
+
+    @property
+    def capabilities(self) -> Dict[str, bool]:
+        return {"vision": True}
+
+    def verify_cover_match(
+        self, image_bytes: bytes, album_meta: Dict[str, Any]
+    ) -> Verdict:
+        if not image_bytes:
+            return self._abstain("no image bytes provided")
+        if not self.api_key:
+            return self._abstain("ANTHROPIC_API_KEY not set")
+        try:
+            import requests
+        except ImportError:
+            return self._abstain("requests not installed")
+
+        media_type = "image/png" if image_bytes[:8] == b"\x89PNG\r\n\x1a\n" else "image/jpeg"
+        url = f"{self.endpoint}/v1/messages"
+        headers = {
+            "x-api-key": self.api_key,
+            "anthropic-version": ANTHROPIC_VERSION,
+            "content-type": "application/json",
+        }
+        body = {
+            "model": self.model,
+            "max_tokens": 1024,
+            "system": SYSTEM_PROMPT,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": media_type,
+                                "data": encode_image_b64(image_bytes),
+                            },
+                        },
+                        {"type": "text", "text": build_user_prompt(album_meta)},
+                    ],
+                }
+            ],
+        }
+        try:
+            resp = requests.post(url, json=body, headers=headers, timeout=self.timeout)
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as exc:  # network/JSON/HTTP -> fail soft
+            return self._abstain(f"anthropic request failed: {exc}")
+
+        if data.get("stop_reason") == "refusal":
+            return self._abstain("model refused the request")
+
+        text = ""
+        for block in data.get("content", []):
+            if isinstance(block, dict) and block.get("type") == "text":
+                text += block.get("text", "")
+        return parse_verdict(text, self.name)

--- a/validators/base.py
+++ b/validators/base.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Base class for pluggable AI cover-art validators.
+
+This mirrors the adapter pattern in ``sources/base.py``. Every AI "second
+opinion" provider (Ollama, OpenAI-compatible, Anthropic, a Hermes/Jarvis
+gateway, or a user's own contrib plugin) inherits from
+:class:`BaseAIValidator` and returns a :class:`Verdict`.
+
+Design rules that keep the toolkit usable by everyone:
+
+  * The deterministic cover checks in ``utilities/core/`` are always-on and do
+    not depend on anything here. This layer is an OPTIONAL second opinion.
+  * The DEFAULT provider is :class:`~validators.null.NullValidator`, which
+    always abstains and makes zero network calls and zero imports of network
+    libraries.
+  * A validator that cannot see images (``capabilities["vision"] is False``)
+    MUST return an ``abstain`` verdict rather than guessing.
+  * Network/SDK dependencies are imported lazily inside methods, never at
+    module top level, so importing this package never requires ``requests`` or
+    any provider SDK.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+# Allowed verdict labels. ``abstain`` means "I did not / could not judge".
+VERDICTS = ("match", "mismatch", "uncertain", "abstain")
+
+
+@dataclass
+class Verdict:
+    """Result of an AI cover-match check.
+
+    Attributes:
+        verdict: One of :data:`VERDICTS`. ``match`` = art fits the album,
+            ``mismatch`` = wrong art, ``uncertain`` = looked but unsure,
+            ``abstain`` = did not judge (default/null/non-vision/error).
+        confidence: 0.0 - 1.0. Callers should treat ``abstain`` as 0.0.
+        notes: Short human-readable explanation.
+        provider: Name of the validator that produced this verdict.
+    """
+
+    verdict: str = "abstain"
+    confidence: float = 0.0
+    notes: str = ""
+    provider: str = "unknown"
+
+    def __post_init__(self) -> None:
+        if self.verdict not in VERDICTS:
+            raise ValueError(
+                f"invalid verdict {self.verdict!r}; expected one of {VERDICTS}"
+            )
+        # Clamp confidence into [0, 1] so downstream thresholds are safe.
+        try:
+            self.confidence = max(0.0, min(1.0, float(self.confidence)))
+        except (TypeError, ValueError):
+            self.confidence = 0.0
+
+    @property
+    def is_mismatch(self) -> bool:
+        """True only for an actual ``mismatch`` verdict."""
+        return self.verdict == "mismatch"
+
+    @property
+    def abstained(self) -> bool:
+        """True when no real judgement was made."""
+        return self.verdict == "abstain"
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to a plain dict (for JSON logging)."""
+        return {
+            "verdict": self.verdict,
+            "confidence": self.confidence,
+            "notes": self.notes,
+            "provider": self.provider,
+        }
+
+
+class BaseAIValidator(ABC):
+    """Abstract base class for AI cover-match validators.
+
+    Subclasses configure themselves from a plain ``config`` dict (typically the
+    ``ai_validation`` block of ``music-config.yaml``) and implement
+    :meth:`verify_cover_match`.
+    """
+
+    #: Stable identifier used in config (``provider:`` field) and the registry.
+    name: str = "base"
+
+    def __init__(self, config: Dict[str, Any] | None = None):
+        """Store config. Do NOT open network connections here.
+
+        Args:
+            config: The ``ai_validation`` config block (or any subset). Common
+                keys: ``endpoint``, ``model``, ``api_key``, ``timeout``.
+        """
+        self.config: Dict[str, Any] = dict(config or {})
+        self.endpoint: str = str(self.config.get("endpoint") or "").rstrip("/")
+        self.model: str = str(self.config.get("model") or "")
+        self.timeout: int = int(self.config.get("timeout") or 60)
+
+    @property
+    def capabilities(self) -> Dict[str, bool]:
+        """What this validator can do, e.g. ``{"vision": True}``.
+
+        Non-vision providers MUST report ``{"vision": False}`` and abstain.
+        """
+        return {"vision": False}
+
+    @abstractmethod
+    def verify_cover_match(
+        self, image_bytes: bytes, album_meta: Dict[str, Any]
+    ) -> Verdict:
+        """Judge whether ``image_bytes`` is the correct cover for an album.
+
+        Args:
+            image_bytes: Raw embedded cover-art bytes (JPEG/PNG).
+            album_meta: Album context, e.g. ``{"album": ..., "artist": ...,
+                "year": ...}``.
+
+        Returns:
+            A :class:`Verdict`. Implementations should NEVER raise for an
+            expected failure (missing endpoint/key, network error); they should
+            return an ``abstain`` verdict so the caller can fail soft.
+        """
+        raise NotImplementedError
+
+    def _abstain(self, notes: str, confidence: float = 0.0) -> Verdict:
+        """Helper to build an ``abstain`` verdict tagged with this provider."""
+        return Verdict(
+            verdict="abstain",
+            confidence=confidence,
+            notes=notes,
+            provider=self.name,
+        )
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(name={self.name!r}, model={self.model!r})"

--- a/validators/contrib/__init__.py
+++ b/validators/contrib/__init__.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Drop-in validators.
+
+Any module placed in this package that exports a
+:class:`~validators.base.BaseAIValidator` subclass is auto-discovered by the
+registry and selectable by its ``name`` attribute via
+``ai_validation.provider`` in ``music-config.yaml``.
+
+See ``example_validator.py`` for a documented template, and
+``docs/AI_VALIDATORS.md`` for the full guide.
+"""

--- a/validators/contrib/example_validator.py
+++ b/validators/contrib/example_validator.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Template contrib validator - copy this to build your own.
+
+This is the documented starting point for the "bring your own validator" path.
+It is intentionally trivial: it does NOT call any network or model. Instead it
+demonstrates the contract every validator must satisfy:
+
+  1. Subclass :class:`~validators.base.BaseAIValidator`.
+  2. Set a unique ``name`` - this is what users put in
+     ``ai_validation.provider`` to select your validator.
+  3. Declare ``capabilities`` (at least ``{"vision": bool}``).
+  4. Implement ``verify_cover_match(image_bytes, album_meta) -> Verdict``.
+     NEVER raise for an expected failure (no key, no model, network down) -
+     return an ``abstain`` verdict so the caller can fail soft.
+
+To make a real validator, replace the body of ``verify_cover_match`` with a
+call to your model/service (import any network library lazily, inside the
+method) and translate its answer into a :class:`~validators.base.Verdict`.
+
+Selecting this template (for testing the plumbing) - in ``music-config.yaml``::
+
+    ai_validation:
+      enabled: true
+      provider: example
+
+Or programmatically::
+
+    from validators import get_validator
+    v = get_validator("example", {})
+    print(v.verify_cover_match(b"...", {"album": "X", "artist": "Y"}))
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from validators.base import BaseAIValidator, Verdict
+
+
+class ExampleValidator(BaseAIValidator):
+    """A no-op example. Returns a deterministic ``uncertain`` verdict.
+
+    Real validators would inspect ``image_bytes`` against ``album_meta`` using a
+    vision model. This one just proves the registry can find and load a contrib
+    module by name and that it returns a well-formed :class:`Verdict`.
+    """
+
+    name = "example"
+
+    @property
+    def capabilities(self) -> Dict[str, bool]:
+        # This template does not actually look at the image.
+        return {"vision": False}
+
+    def verify_cover_match(
+        self, image_bytes: bytes, album_meta: Dict[str, Any]
+    ) -> Verdict:
+        if not image_bytes:
+            return self._abstain("no image bytes provided")
+        album = album_meta.get("album") or album_meta.get("title") or "(unknown album)"
+        return Verdict(
+            verdict="uncertain",
+            confidence=0.5,
+            notes=f"example validator received {len(image_bytes)} bytes for {album!r}",
+            provider=self.name,
+        )

--- a/validators/hermes.py
+++ b/validators/hermes.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Validator for a configurable Hermes/Jarvis-style gateway.
+
+This is the "bring your own gateway" provider: it POSTs the image and album
+metadata to a single HTTP endpoint you control (a local Hermes/Jarvis service,
+a homelab inference gateway, or any small server that wraps a vision model).
+The owner of this toolkit wires it to their own validator; the public can point
+it at anything that speaks the simple request/response contract below.
+
+Request (JSON POST to ``endpoint``):
+    {
+      "model": "<configured model or empty>",
+      "album": {...album_meta...},
+      "image_base64": "<base64 jpeg/png>",
+      "prompt": "<text question>"
+    }
+
+Response (any of these shapes is accepted):
+    {"verdict": "match|mismatch|uncertain", "confidence": 0.0-1.0, "notes": "..."}
+  or a chat-style ``{"response": "<text>"}`` / ``{"content": "<text>"}`` /
+  ``{"message": {"content": "<text>"}}`` that is parsed leniently.
+
+``requests`` is imported lazily; any failure degrades to ``abstain``.
+
+Config keys (from the ``ai_validation`` block):
+  * ``endpoint``: full gateway URL to POST to (required; no default)
+  * ``model``: optional model hint forwarded to the gateway
+  * ``api_key``: optional bearer token. Falls back to ``HERMES_API_KEY``.
+  * ``timeout``: seconds, default 60
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from ._prompt import build_user_prompt, encode_image_b64, parse_verdict
+from .base import BaseAIValidator, Verdict
+
+
+class HermesValidator(BaseAIValidator):
+    """Vision validator that POSTs to a configurable gateway endpoint."""
+
+    name = "hermes"
+
+    def __init__(self, config: Dict[str, Any] | None = None):
+        super().__init__(config)
+        self.api_key = str(
+            self.config.get("api_key") or os.environ.get("HERMES_API_KEY") or ""
+        )
+
+    @property
+    def capabilities(self) -> Dict[str, bool]:
+        # The gateway is assumed to wrap a vision model.
+        return {"vision": True}
+
+    def verify_cover_match(
+        self, image_bytes: bytes, album_meta: Dict[str, Any]
+    ) -> Verdict:
+        if not image_bytes:
+            return self._abstain("no image bytes provided")
+        if not self.endpoint:
+            return self._abstain("no gateway endpoint configured")
+        try:
+            import requests
+        except ImportError:
+            return self._abstain("requests not installed")
+
+        headers = {"content-type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        body = {
+            "model": self.model,
+            "album": album_meta,
+            "image_base64": encode_image_b64(image_bytes),
+            "prompt": build_user_prompt(album_meta),
+        }
+        try:
+            resp = requests.post(
+                self.endpoint, json=body, headers=headers, timeout=self.timeout
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as exc:  # network/JSON/HTTP -> fail soft
+            return self._abstain(f"hermes gateway request failed: {exc}")
+
+        # Structured verdict straight from the gateway?
+        if isinstance(data, dict) and data.get("verdict"):
+            try:
+                return Verdict(
+                    verdict=str(data.get("verdict")).strip().lower(),
+                    confidence=float(data.get("confidence", 0.5)),
+                    notes=str(data.get("notes") or "")[:300],
+                    provider=self.name,
+                )
+            except (ValueError, TypeError):
+                pass  # fall through to lenient text parsing
+
+        # Otherwise pull text out of a chat-style payload and parse leniently.
+        text = _extract_text(data)
+        return parse_verdict(text, self.name)
+
+
+def _extract_text(data: Any) -> str:
+    """Best-effort text extraction from a variety of gateway payload shapes."""
+    if isinstance(data, str):
+        return data
+    if isinstance(data, dict):
+        for key in ("response", "content", "text", "output"):
+            value = data.get(key)
+            if isinstance(value, str) and value:
+                return value
+        message = data.get("message")
+        if isinstance(message, dict) and isinstance(message.get("content"), str):
+            return message["content"]
+    return ""

--- a/validators/null.py
+++ b/validators/null.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""The DEFAULT validator: always abstain, never touch the network.
+
+:class:`NullValidator` is what the toolkit uses when AI validation is disabled
+(the default) or when ``provider: null`` is configured. It guarantees:
+
+  * zero network calls,
+  * zero imports of ``requests`` or any provider SDK,
+  * an ``abstain`` verdict for every input.
+
+Keeping this trivial is the whole point: the public, zero-config experience
+must never require an AI key, a local model, or an internet connection.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .base import BaseAIValidator, Verdict
+
+
+class NullValidator(BaseAIValidator):
+    """No-op validator that always abstains."""
+
+    name = "null"
+
+    @property
+    def capabilities(self) -> Dict[str, bool]:
+        return {"vision": False}
+
+    def verify_cover_match(
+        self, image_bytes: bytes, album_meta: Dict[str, Any]
+    ) -> Verdict:
+        return self._abstain("AI validation disabled (NullValidator)")

--- a/validators/ollama.py
+++ b/validators/ollama.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Local-vision validator backed by Ollama (e.g. llava, llama3.2-vision).
+
+Talks to a local Ollama server's ``/api/chat`` endpoint. Nothing leaves the
+machine, so this is the recommended provider for users who want a private
+second opinion. ``requests`` is imported lazily so the package imports cleanly
+without it; any error degrades to an ``abstain`` verdict.
+
+Config keys (from the ``ai_validation`` block):
+  * ``endpoint``: base URL, default ``http://localhost:11434``
+  * ``model``: vision model name, default ``llava``
+  * ``timeout``: seconds, default 60
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ._prompt import SYSTEM_PROMPT, build_user_prompt, encode_image_b64, parse_verdict
+from .base import BaseAIValidator, Verdict
+
+DEFAULT_ENDPOINT = "http://localhost:11434"
+DEFAULT_MODEL = "llava"
+
+
+class OllamaValidator(BaseAIValidator):
+    """Vision validator using a local Ollama server."""
+
+    name = "ollama"
+
+    def __init__(self, config: Dict[str, Any] | None = None):
+        super().__init__(config)
+        self.endpoint = self.endpoint or DEFAULT_ENDPOINT
+        self.model = self.model or DEFAULT_MODEL
+
+    @property
+    def capabilities(self) -> Dict[str, bool]:
+        return {"vision": True}
+
+    def verify_cover_match(
+        self, image_bytes: bytes, album_meta: Dict[str, Any]
+    ) -> Verdict:
+        if not image_bytes:
+            return self._abstain("no image bytes provided")
+        try:
+            import requests
+        except ImportError:
+            return self._abstain("requests not installed")
+
+        url = f"{self.endpoint}/api/chat"
+        body = {
+            "model": self.model,
+            "stream": False,
+            "messages": [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {
+                    "role": "user",
+                    "content": build_user_prompt(album_meta),
+                    "images": [encode_image_b64(image_bytes)],
+                },
+            ],
+        }
+        try:
+            resp = requests.post(url, json=body, timeout=self.timeout)
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as exc:  # network/JSON/HTTP -> fail soft
+            return self._abstain(f"ollama request failed: {exc}")
+
+        content = (data.get("message") or {}).get("content", "")
+        return parse_verdict(content, self.name)

--- a/validators/openai_compat.py
+++ b/validators/openai_compat.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Validator for any OpenAI-compatible chat-completions endpoint.
+
+Works with LM Studio, vLLM, OpenRouter, llama.cpp server, and the OpenAI API
+itself - anything that speaks ``POST /v1/chat/completions`` with vision message
+parts (``image_url`` content blocks). ``requests`` is imported lazily; any
+failure degrades to ``abstain``.
+
+Config keys (from the ``ai_validation`` block):
+  * ``endpoint``: base URL incl. ``/v1`` if required, e.g.
+    ``http://localhost:1234/v1`` (LM Studio) or ``https://api.openai.com/v1``
+  * ``model``: vision-capable model name, e.g. ``gpt-4o-mini``
+  * ``api_key``: bearer token (optional for local servers). Falls back to the
+    ``OPENAI_API_KEY`` environment variable.
+  * ``timeout``: seconds, default 60
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from ._prompt import (
+    SYSTEM_PROMPT,
+    build_user_prompt,
+    encode_image_data_url,
+    parse_verdict,
+)
+from .base import BaseAIValidator, Verdict
+
+DEFAULT_ENDPOINT = "http://localhost:1234/v1"
+DEFAULT_MODEL = "gpt-4o-mini"
+
+
+class OpenAICompatValidator(BaseAIValidator):
+    """Vision validator for OpenAI-compatible servers."""
+
+    name = "openai_compat"
+
+    def __init__(self, config: Dict[str, Any] | None = None):
+        super().__init__(config)
+        self.endpoint = self.endpoint or DEFAULT_ENDPOINT
+        self.model = self.model or DEFAULT_MODEL
+        self.api_key = str(
+            self.config.get("api_key") or os.environ.get("OPENAI_API_KEY") or ""
+        )
+
+    @property
+    def capabilities(self) -> Dict[str, bool]:
+        return {"vision": True}
+
+    def verify_cover_match(
+        self, image_bytes: bytes, album_meta: Dict[str, Any]
+    ) -> Verdict:
+        if not image_bytes:
+            return self._abstain("no image bytes provided")
+        try:
+            import requests
+        except ImportError:
+            return self._abstain("requests not installed")
+
+        url = f"{self.endpoint}/chat/completions"
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        body = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": build_user_prompt(album_meta)},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": encode_image_data_url(image_bytes)},
+                        },
+                    ],
+                },
+            ],
+        }
+        try:
+            resp = requests.post(url, json=body, headers=headers, timeout=self.timeout)
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as exc:  # network/JSON/HTTP -> fail soft
+            return self._abstain(f"openai-compatible request failed: {exc}")
+
+        try:
+            content = data["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError):
+            return self._abstain("unexpected response shape")
+        return parse_verdict(_content_to_text(content), self.name)
+
+
+def _content_to_text(content: Any) -> str:
+    """Normalize a chat message ``content`` to text.
+
+    Some OpenAI-compatible servers return ``content`` as a list of parts
+    (``[{"type": "text", "text": "..."}, ...]``) rather than a plain string.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict) and isinstance(item.get("text"), str):
+                parts.append(item["text"])
+        return "".join(parts)
+    return ""

--- a/validators/registry.py
+++ b/validators/registry.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Validator discovery and construction.
+
+Resolves a provider name (from the ``ai_validation.provider`` config field) to a
+constructed :class:`~validators.base.BaseAIValidator`. Resolution order:
+
+  1. Built-in providers shipped in this package (null, ollama, openai_compat,
+     anthropic, hermes).
+  2. ``validators/contrib/`` modules - drop a file in there exporting a
+     ``BaseAIValidator`` subclass and it is discoverable by ``name``.
+  3. Installed packages that register an entry point in the
+     ``music_toolkit.validators`` group (the "bring your own validator,
+     pip-installable" path).
+
+Unknown names fall back to :class:`~validators.null.NullValidator` so the
+toolkit never crashes on a typo - it just abstains.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+from typing import Any, Dict, Optional, Type
+
+from .base import BaseAIValidator
+from .null import NullValidator
+
+ENTRY_POINT_GROUP = "music_toolkit.validators"
+
+# Built-in providers keyed by their stable name. Imported lazily in
+# _load_builtin so importing the package (and registry) never imports requests.
+_BUILTIN_MODULES = {
+    "null": ("validators.null", "NullValidator"),
+    "ollama": ("validators.ollama", "OllamaValidator"),
+    "openai_compat": ("validators.openai_compat", "OpenAICompatValidator"),
+    "anthropic": ("validators.anthropic", "AnthropicValidator"),
+    "hermes": ("validators.hermes", "HermesValidator"),
+}
+
+
+def _load_builtin(name: str) -> Optional[Type[BaseAIValidator]]:
+    spec = _BUILTIN_MODULES.get(name)
+    if not spec:
+        return None
+    module_name, class_name = spec
+    module = importlib.import_module(module_name)
+    return getattr(module, class_name)
+
+
+def _iter_contrib_classes():
+    """Yield (name, class) for every BaseAIValidator subclass in contrib/."""
+    from . import contrib  # local import keeps package import cheap
+
+    for module_info in pkgutil.iter_modules(contrib.__path__):
+        try:
+            module = importlib.import_module(f"{contrib.__name__}.{module_info.name}")
+        except Exception:
+            continue  # a broken contrib module must not break discovery
+        for _, obj in inspect.getmembers(module, inspect.isclass):
+            if (
+                issubclass(obj, BaseAIValidator)
+                and obj is not BaseAIValidator
+                and obj.__module__ == module.__name__
+            ):
+                yield getattr(obj, "name", module_info.name), obj
+
+
+def _load_contrib(name: str) -> Optional[Type[BaseAIValidator]]:
+    for candidate_name, obj in _iter_contrib_classes():
+        if candidate_name == name:
+            return obj
+    return None
+
+
+def _load_entry_point(name: str) -> Optional[Type[BaseAIValidator]]:
+    try:
+        from importlib.metadata import entry_points
+    except ImportError:  # pragma: no cover - Python < 3.8
+        return None
+
+    try:
+        eps = entry_points(group=ENTRY_POINT_GROUP)
+    except TypeError:  # pragma: no cover - older importlib.metadata API
+        eps = entry_points().get(ENTRY_POINT_GROUP, [])
+
+    for ep in eps:
+        if ep.name == name:
+            try:
+                obj = ep.load()
+            except Exception:
+                continue
+            if inspect.isclass(obj) and issubclass(obj, BaseAIValidator):
+                return obj
+    return None
+
+
+def get_validator(name: Optional[str], config: Dict[str, Any] | None = None) -> BaseAIValidator:
+    """Construct the validator named ``name``, configured with ``config``.
+
+    Falls back to :class:`NullValidator` when ``name`` is missing, empty,
+    ``"null"``, or cannot be resolved - so callers always get a usable
+    validator and never an exception for a bad provider name.
+    """
+    config = config or {}
+    if not name or name == "null":
+        return NullValidator(config)
+
+    cls = _load_builtin(name) or _load_contrib(name) or _load_entry_point(name)
+    if cls is None:
+        # Unknown provider: degrade to abstain rather than crash.
+        return NullValidator(config)
+    return cls(config)
+
+
+def available_validators() -> Dict[str, str]:
+    """Return a ``name -> source`` map of every discoverable validator.
+
+    ``source`` is ``"builtin"``, ``"contrib"``, or ``"entry_point"``. Useful for
+    CLIs and docs ("which validators can I pick?").
+    """
+    found: Dict[str, str] = {name: "builtin" for name in _BUILTIN_MODULES}
+    for name, _ in _iter_contrib_classes():
+        found.setdefault(name, "contrib")
+    try:
+        from importlib.metadata import entry_points
+
+        try:
+            eps = entry_points(group=ENTRY_POINT_GROUP)
+        except TypeError:  # pragma: no cover
+            eps = entry_points().get(ENTRY_POINT_GROUP, [])
+        for ep in eps:
+            found.setdefault(ep.name, "entry_point")
+    except Exception:
+        pass
+    return found


### PR DESCRIPTION
## Summary

Adds an OPTIONAL, pluggable AI "second opinion" layer for visual cover-art matching, mirroring the `sources/` adapter pattern. The deterministic core checks in `utilities/core/` stay always-on; this layer is purely additive and **the default requires zero AI and zero network**.

## What's included

- **`validators/` package**
  - `base.py`: `BaseAIValidator` ABC with a `capabilities` property and a `Verdict` dataclass (`verdict in {match,mismatch,uncertain,abstain}`, `confidence`, `notes`, `provider`); primary method `verify_cover_match(image_bytes, album_meta) -> Verdict`.
  - `null.py`: `NullValidator` (DEFAULT) — always abstains, no network-lib imports, zero calls.
  - `ollama.py` (local llava via `/api/chat`), `openai_compat.py` (LM Studio / vLLM / OpenRouter / OpenAI vision parts), `anthropic.py` (Claude vision Messages API, raw HTTP to keep the zero-anthropic-SDK invariant), `hermes.py` (configurable Hermes/Jarvis gateway). All import `requests` lazily and degrade to `abstain` on any error.
  - `registry.py`: `get_validator(name, config)` with `validators/contrib/` scanning **plus** `importlib.metadata` entry-point discovery (`music_toolkit.validators` group). Unknown names degrade to `NullValidator`.
  - `contrib/example_validator.py`: documented template.
- **`utilities/ai_validate_covers.py`**: CLI that scans a path, extracts embedded art via core (read-only import), runs the configured validator; high-confidence mismatches are logged to `.claude/knowledge/patterns.json` (NON-destructive — never deletes/replaces art). `fail_mode: soft` logs AI errors and continues.
- **Config/docs**: `music-config.yaml` `ai_validation` block (`enabled:false` / `provider:null`), `docs/AI_VALIDATORS.md`, `.claude/commands/ai-validate-covers.md`, a README "Bring your own validator" section, and credential placeholders.
- **`tests/test_validators.py`**: NullValidator abstains; registry loads `contrib/example_validator.py` by name and returns a `Verdict`; plus JSON-with-trailing-prose, negation, and non-string-content parsing robustness.

## Verification

- `python -m pytest tests/ -q` → **36 passed**.
- E2E: with the default config (`enabled:false` / NullValidator), `python utilities/ai_validate_covers.py <album>` runs with **zero network calls** and reports `abstain`.

## Notes

A self code-review (high effort) surfaced and fixed three real issues before this PR: greedy `{.*}` JSON extraction (now first-balanced-object via `JSONDecoder.raw_decode`), negation-blind keyword fallback (now conservative `uncertain`), and non-string OpenAI-compatible `content` handling. All network imports are lazy; no files outside the owned set were modified (core is imported read-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWhdpZqWE7QNtTFYYS3Z3T