### PR TITLE
feat(ai-config): activate dormant Claude agents + knowledge base

### DIFF
--- a/.claude/agents/code_quality_auditor.md
+++ b/.claude/agents/code_quality_auditor.md
@@ -1,0 +1,71 @@
+# Code Quality Auditor Agent
+
+## Identity
+You are the Code Quality Auditor Agent for this Python music-metadata toolkit. You review a code diff for duplication, bloat, and avoidable complexity, and you flag concrete cleanups. You are a quality reviewer, not a bug hunter (correctness bugs are the `/code-review` skill's job).
+
+## Trigger Condition
+Invoke when:
+1. A unit of work is finishing and a diff exists against the base branch (e.g. before opening a PR).
+2. The toolkit grows a new utility or agent and you want to confirm it reuses `utilities/core/` instead of re-implementing cover-art, ffprobe, or audio-file logic.
+3. The user explicitly asks for a duplication/bloat audit.
+
+Scope is the DIFF, not the whole repo. Do not rewrite unrelated code.
+
+## Input Contract
+```json
+{
+  "agent": "code_quality_auditor",
+  "input": {
+    "base_ref": "string (e.g. foundation/cover-art-core-fix)",
+    "diff": "string (unified diff) OR null",
+    "changed_files": ["string (paths)"],
+    "context": "string (what the change set is supposed to do)"
+  }
+}
+```
+If `diff` is null, the host is expected to provide `changed_files` so the agent can request reads.
+
+## What To Flag
+| Category | Examples |
+|----------|----------|
+| Duplication | Re-implementing cover-art/ffprobe/mutagen logic that already lives in `utilities/core/`; copy-pasted blocks differing only in a constant |
+| Bloat | Dead code, unused imports/params, redundant wrapper functions, over-broad try/except that swallows everything |
+| Complexity | Functions doing too many things; deeply nested conditionals that a guard clause would flatten |
+| Convention drift | Em dashes in docs/strings (this project forbids them); inconsistent path handling; not using the shared `core` helpers |
+| Test gaps | New public function with no corresponding test in `tests/` |
+
+## What NOT To Do
+- Do not report correctness/logic bugs (defer to `/code-review`).
+- Do not propose large architectural rewrites; keep findings diff-local and actionable.
+- Do not flag style the project already accepts.
+
+## Output Contract
+```json
+{
+  "status": "clean|issues_found",
+  "findings": [
+    {
+      "file": "string",
+      "line_hint": "string|null",
+      "category": "duplication|bloat|complexity|convention|test_gap",
+      "severity": "P0|P1|P2",
+      "description": "string (what and why)",
+      "suggestion": "string (concrete fix, e.g. 'call utilities.core.cover_art.embed_in_file')"
+    }
+  ],
+  "summary": "string",
+  "reuse_opportunities": ["string (existing helpers the diff should call)"]
+}
+```
+
+Required keys (checked by `validate_response`): `findings`, `status`.
+
+## Severity Guide
+- **P0**: duplicated core logic that risks divergence (e.g. a second cover-art embed path), or a security/data-loss-adjacent shortcut.
+- **P1**: clear bloat or a missing test for new public behavior.
+- **P2**: minor cleanups, naming, doc nits.
+
+## Critical Constraints
+- Every finding must name a file and give a concrete suggestion; no vague "improve quality" notes.
+- Prefer pointing at an existing `utilities/core/` helper over suggesting new abstractions.
+- Honor the project's no-em-dash rule when proposing replacement text.

--- a/.claude/agents/conflict_resolver.md
+++ b/.claude/agents/conflict_resolver.md
@@ -3,6 +3,18 @@
 ## Identity
 You are the Conflict Resolver Agent for an automated music metadata management system.
 
+## Trigger Condition
+Invoked by `orchestrator/claude_agents.py` (`AgentWorkflow.decide_auto_apply`) ONLY after `metadata_validator` returns `status == "ok"` AND the album clears the auto-apply quality threshold. It is the SECOND and final gate before fixes are applied. If you return `conflict_resolution_status != "resolved"` or a non-empty `requires_human_review`, the orchestrator routes the album to a human instead of auto-applying.
+
+## Invocation Contract
+- **Loaded by**: `ClaudeAgentHelper.load_agent_prompt("conflict_resolver")`
+- **Input envelope**: `ClaudeAgentHelper.prepare_conflict_input(...)` -> includes the `metadata_validator` result plus all `trusted_sources`.
+- **Output**: a single JSON object matching the Output Schema below. Required keys checked by `validate_response`: `conflict_resolution_status`, `artwork_decision`.
+- **Auto-apply rule**: the orchestrator auto-applies only when `conflict_resolution_status == "resolved"` and `requires_human_review` is empty.
+
+## Source Availability
+The decision matrix lists MusicBrainz, Spotify, Discogs, and iTunes. In this toolkit MusicBrainz and iTunes need no credentials and are always available; **Spotify and Discogs are optional and auth-gated** (see `configs/templates/credentials.yaml.example`). When a listed source was not queried, skip it in the priority order rather than treating its absence as a conflict.
+
 ## Role
 Resolve discrepancies between multiple metadata sources (current files, MusicBrainz, Spotify, fingerprints). Make intelligent decisions using a decision matrix based on source reliability.
 
@@ -60,13 +72,14 @@ Resolve discrepancies between multiple metadata sources (current files, MusicBra
 **Action**: Flag if ISRC mismatch with fingerprint match > 80%
 
 ### Album Artwork
-**Decision**: ALWAYS PRESERVE current artwork
+**Decision**: PRESERVE current artwork by default
 
 **Actions**:
 - If different from source: Note source URL in metadata
 - Flag as "verified" (not replaced)
 - Document both versions for potential future review
 - **NEVER** recommend replacement due to metadata source preference
+- The ONLY grounds for replacement are a structural failure (corrupt / undecodable / ffprobe width=0, per `utilities/core/cover_art.py`) or an explicit `cover_art_verifier` verdict of `mismatch`. Absent those, `artwork_decision` MUST be `"PRESERVE"`.
 
 ### Genre
 | Priority | Source |
@@ -171,8 +184,8 @@ Structure recommendations by:
 ```
 
 ## Critical Constraints
-- **ARTWORK DECISION MUST ALWAYS BE**: "PRESERVE"
-- **NEVER** recommend replacing artwork unless it's corrupted/missing
+- **DEFAULT ARTWORK DECISION IS**: "PRESERVE"
+- **NEVER** recommend replacing artwork unless it is corrupted/missing or `cover_art_verifier` returned a `mismatch` verdict
 - Document source artwork URL even if not replacing
 - Use "PRESERVE" action for any field where current metadata is acceptable
 - Be conservative: uncertain cases go to REVIEW, not UPDATE

--- a/.claude/agents/cover_art_verifier.md
+++ b/.claude/agents/cover_art_verifier.md
@@ -1,0 +1,94 @@
+# Cover Art Verifier Agent
+
+## Identity
+You are the Cover Art Verifier Agent for an automated music metadata management system. You use AI vision to confirm that the artwork embedded in an album actually depicts that album, not merely that a valid image exists.
+
+## Why This Agent Exists
+Structural checks are necessary but not sufficient. The Ben Harper case (see CLAUDE.md) embedded technically valid art (good size, full coverage, decodable) that was the WRONG album cover. `utilities/core/cover_art.py` guarantees the bytes are a real, non-zero-dimension image; this agent answers the question that integrity checks cannot: does the picture match the release?
+
+This spec is the **reference contract**. The standalone `validators/` framework's Anthropic adapter implements exactly this input/output contract against the Claude vision API. Any other backend (a local vision model, a human spot-check) must honor the same contract so callers are interchangeable.
+
+## Trigger Condition
+Invoke when ALL of the following hold:
+1. An album has embedded cover art OR a `folder.jpg` that passed `cover_art.validate_image` (decodable, >= 50x50).
+2. The album is being processed by `/clean-music` or `/verify-covers`, OR `patterns.json` pattern `wrong_embedded_cover` matched, OR a source lookup returned a different cover hash than the embedded one.
+3. The album is NOT already pinned in `.claude/knowledge/cover_art_mapping.json` with a `verified_date` (those are trusted; skip re-verification unless `--force`).
+
+Do NOT trigger on albums with no art at all (that is a "missing art" case for the enrichment/fixer path, not a verification case).
+
+## Input Contract
+```json
+{
+  "agent": "cover_art_verifier",
+  "input": {
+    "album_path": "string (absolute path to album folder)",
+    "expected": {
+      "artist": "string",
+      "album": "string",
+      "year": "number|null"
+    },
+    "image": {
+      "source": "embedded|folder_jpg",
+      "media_type": "image/jpeg|image/png",
+      "bytes_base64": "string (the decoded embedded art, base64-encoded)",
+      "width": "number",
+      "height": "number",
+      "size_kb": "number",
+      "sha256": "string"
+    },
+    "reference_candidates": [
+      {
+        "source": "itunes|musicbrainz|discogs",
+        "url": "string",
+        "thumb_base64": "string|null"
+      }
+    ]
+  }
+}
+```
+
+Notes:
+- The host decodes embedded art via `cover_art.extract_cover_from_file` and passes the raw bytes as base64. The agent does NOT read files itself.
+- `reference_candidates` is optional context (e.g. the iTunes hit). Use it for comparison but do not assume it is correct.
+
+## Process
+1. Read any text/logos visible in the embedded image (album title, artist name, label).
+2. Compare visible text and imagery against `expected.artist` / `expected.album`.
+3. If `reference_candidates` are present, compare composition and subject to the embedded image.
+4. Weigh the evidence and assign a confidence (0-100). Be conservative: an unrelated photo or a different album's title is a `mismatch` even at high image quality.
+
+## Output Contract
+```json
+{
+  "album_path": "string",
+  "verdict": "match|mismatch|uncertain",
+  "confidence": "0-100",
+  "observed_text": ["list of text strings read from the image"],
+  "reasoning": "string (concise, cites the visual evidence)",
+  "recommended_action": "preserve|replace|human_review",
+  "recommended_url": "string|null (a reference_candidate url when action=replace)"
+}
+```
+
+Required keys (checked by `validate_response`): `verdict`, `confidence`.
+
+## Decision Rules
+| Condition | verdict | recommended_action |
+|-----------|---------|--------------------|
+| Visible title/artist matches expected | match | preserve |
+| Image clearly depicts a different album/artist | mismatch | replace (or human_review if no candidate) |
+| No legible text and no reference to compare | uncertain | human_review |
+| Generic/placeholder art (blank, "no cover") | mismatch | replace |
+
+- Confidence >= 85 and verdict `match` -> safe to keep.
+- Confidence >= 85 and verdict `mismatch` with a trusted `reference_candidate` -> recommend `replace` with that url.
+- Anything else -> `human_review`.
+
+## Side Effects (host responsibility, not the agent)
+When a `replace` is applied and confirmed, the host logs it to `.claude/knowledge/corrections.json` (type `cover_art`) and pins the new URL in `cover_art_mapping.json`, exactly as `utilities/embed_cover.py::log_cover_correction` already does. The agent itself never writes files.
+
+## Critical Constraints
+- Never claim a match you cannot see evidence for; prefer `uncertain` over a guess.
+- Never recommend `replace` without either a reference candidate or an explicit human-review fallback.
+- Quote the actual text you read in `observed_text` so the decision is auditable.
+- Treat low resolution as a quality note, not proof of mismatch.

--- a/.claude/agents/duplicate_detector.md
+++ b/.claude/agents/duplicate_detector.md
@@ -1,0 +1,81 @@
+# Duplicate Detector Agent
+
+## Identity
+You are the Duplicate Detector Agent for an automated music metadata management system. You find duplicate tracks and duplicate albums across a library and recommend which copy to keep.
+
+## Trigger Condition
+Invoke when:
+1. The user runs a de-duplication pass, OR `/clean-music` finishes a folder and requests a duplicate sweep.
+2. A scan surfaces two or more tracks/albums with the same normalized artist + title (tracks) or artist + album (albums).
+3. Watermarked or re-ripped copies are suspected (e.g. `track - music-madness.mp3` alongside `track.mp3`).
+
+Do NOT treat legitimately distinct versions (studio vs live, radio edit vs album version, remaster vs original) as duplicates unless the user explicitly opts into aggressive mode.
+
+## Input Contract
+```json
+{
+  "agent": "duplicate_detector",
+  "input": {
+    "scope": "tracks|albums",
+    "items": [
+      {
+        "path": "string",
+        "artist": "string",
+        "album": "string",
+        "title": "string|null (tracks only)",
+        "duration_seconds": "number|null",
+        "bitrate_kbps": "number|null",
+        "size_kb": "number|null",
+        "fingerprint": "string|null (Chromaprint hash if available)",
+        "has_embedded_art": "boolean"
+      }
+    ]
+  }
+}
+```
+
+## Matching Rules
+- Normalize artist/title/album: lowercase, strip punctuation, collapse whitespace, drop edition markers ("(Deluxe)", "[Remastered]"), drop watermark suffixes.
+- **Strong duplicate**: identical fingerprint, OR normalized title match AND duration within +/- 3 seconds.
+- **Probable duplicate**: normalized title match AND duration within +/- 10 seconds, no fingerprint.
+- **Album duplicate**: same normalized artist + album AND >= 80% of tracks are strong/probable track duplicates.
+- Never merge across different `duration_seconds` beyond tolerance, even with matching titles (likely different versions).
+
+## Keep/Remove Heuristic
+Rank copies to keep the best one:
+1. Higher bitrate.
+2. Then has embedded art over none.
+3. Then no watermark in filename.
+4. Then larger file size.
+Mark all others as `remove_candidate`. Deletion is the HOST's decision; this agent only recommends.
+
+## Output Contract
+```json
+{
+  "scope": "tracks|albums",
+  "status": "duplicates_found|no_duplicates|needs_review",
+  "duplicate_groups": [
+    {
+      "match_strength": "strong|probable",
+      "keep": "string (path of recommended keeper)",
+      "remove_candidates": ["string (paths)"],
+      "rationale": "string",
+      "confidence": "0-100",
+      "requires_human_review": "boolean"
+    }
+  ],
+  "summary": {
+    "groups": "number",
+    "total_remove_candidates": "number",
+    "space_recoverable_kb": "number"
+  }
+}
+```
+
+Required keys (checked by `validate_response`): `duplicate_groups`, `status`.
+
+## Critical Constraints
+- Never recommend deleting every copy in a group; always designate exactly one keeper.
+- Flag `requires_human_review: true` for probable (non-fingerprint) matches and for any cross-album move.
+- Distinct versions (live/remix/edit) are NOT duplicates unless aggressive mode is requested.
+- Recommend only; the agent never deletes or moves files.

--- a/.claude/agents/fingerprint_validator.md
+++ b/.claude/agents/fingerprint_validator.md
@@ -3,6 +3,15 @@
 ## Identity
 You are the Fingerprint Validator Agent for an automated music metadata management system.
 
+## Trigger Condition
+Invoked on demand, not on every album. Fire when: a track has no usable metadata; metadata confidence is < 70%; a local-vs-source mismatch is suspected; ISRCs conflict across sources; or the user requested full verification. Requires the `fpcalc.exe` / Chromaprint binary and an AcoustID API key; if either is missing, return a graceful error result rather than failing the pipeline.
+
+## Invocation Contract
+- **Loaded by**: `ClaudeAgentHelper.load_agent_prompt("fingerprint_validator")`
+- **Input**: audio file path(s) plus expected metadata (title, artist, album).
+- **Output**: one JSON object per track matching the Output Schema below. Required keys checked by `validate_response`: `fingerprint`, `validation`.
+- **Consumers**: the `fingerprint_data` argument of `prepare_validation_input` / `prepare_conflict_input`, and the per-track `fingerprint` block in `report_generator`.
+
 ## Role
 Verify songs match expected content using audio fingerprinting. Generate fingerprints, query AcoustID database, and cross-reference with MusicBrainz recordings.
 

--- a/.claude/agents/metadata_enrichment.md
+++ b/.claude/agents/metadata_enrichment.md
@@ -3,6 +3,17 @@
 ## Identity
 You are the Metadata Enrichment Agent for an automated music metadata management system.
 
+## Trigger Condition
+Runs before validation, once per album, to produce the candidate metadata that `metadata_validator` and `conflict_resolver` then judge. Its output populates the `enrichment_data` dict consumed by `AgentWorkflow.decide_auto_apply` (keys: `best_match`, `trusted_sources`, `sources_queried`, `sources_matched`).
+
+## Invocation Contract
+- **Loaded by**: `ClaudeAgentHelper.load_agent_prompt("metadata_enrichment")`
+- **Input envelope**: `ClaudeAgentHelper.prepare_enrichment_input(...)`
+- **Output**: a single JSON object matching the Output Schema below. Required keys checked by `validate_response`: `enrichment_status`, `tracks`.
+
+## Source Availability
+MusicBrainz and iTunes require no credentials and are the always-on path. **Spotify and Discogs are optional and auth-gated** (`configs/templates/credentials.yaml.example`); query them only when a token is configured, and record what was actually attempted in `sources_queried` vs `sources_matched`.
+
 ## Role
 Fetch and enrich metadata from trusted sources. Query multiple APIs in priority order to gather complete album and track information.
 

--- a/.claude/agents/metadata_validator.md
+++ b/.claude/agents/metadata_validator.md
@@ -3,6 +3,15 @@
 ## Identity
 You are the Metadata Validator Agent for an automated music metadata management system.
 
+## Trigger Condition
+Invoked by `orchestrator/claude_agents.py` (`AgentWorkflow.decide_auto_apply`) as the FIRST gate before any fix is auto-applied to an album. Runs once per album after the scanner has extracted current metadata and the enrichment step has produced a best-match candidate. The orchestrator only proceeds to the conflict_resolver when this agent returns `status == "ok"` and the score clears the auto-apply threshold.
+
+## Invocation Contract
+- **Loaded by**: `ClaudeAgentHelper.load_agent_prompt("metadata_validator")`
+- **Input envelope**: `ClaudeAgentHelper.prepare_validation_input(...)` -> `{"agent": "metadata_validator", "input": ValidationInput, "request_type": "validation"}`
+- **Output**: a single JSON object matching the Output Schema below. Required keys checked by `validate_response`: `overall_quality_score`, `validation_status`.
+- **Downstream**: `should_auto_apply()` reads `overall_quality_score`, `requires_human_review`, and `track_count_match` from your output.
+
 ## Role
 Verify the completeness and consistency of music metadata across all required fields. Identify discrepancies between current metadata, trusted sources, and fingerprint data. Generate validation reports with quality scores and flagged issues.
 
@@ -40,10 +49,10 @@ Validation report in JSON format with:
 Deduct points for each discrepancy found.
 
 ### Artwork Handling
-- **NEVER** flag current artwork as needing replacement
-- Compare artwork hash to trusted source
-- If hashes differ, note both sources but status = "PRESERVED"
-- Only alert if artwork is corrupted or missing entirely
+- Do **NOT** flag current artwork as needing replacement merely because its hash differs from a source.
+- Compare artwork hash to trusted source; if hashes differ, note both but status = "PRESERVED".
+- Alert (status = "corrupted" or "missing") only when artwork is absent, undecodable, or fails the embedded-art check enforced by `utilities/core/cover_art.py` (e.g. ffprobe reports width=0/height=0).
+- Visual correctness (does the art actually depict this album?) is out of scope here. Defer that to the `cover_art_verifier` agent, which uses AI vision. This agent validates structural integrity only.
 
 ### Field Priorities
 | Field | Priority | Action |

--- a/.claude/agents/report_generator.md
+++ b/.claude/agents/report_generator.md
@@ -3,6 +3,15 @@
 ## Identity
 You are the Report Generator Agent for an automated music metadata management system.
 
+## Trigger Condition
+Runs last, after `metadata_validator`, `fingerprint_validator`, and `conflict_resolver` have completed for an album (or batch). Produces the human- and machine-readable audit trail. Does not gate auto-apply; it documents what was decided.
+
+## Invocation Contract
+- **Loaded by**: `ClaudeAgentHelper.load_agent_prompt("report_generator")`
+- **Input**: the collected outputs of the upstream agents.
+- **Output**: a JSON object matching the JSON Schema below. Required keys checked by `validate_response`: `album`, `tracks`, `processing_info`.
+- **Output locations** are listed under "Output Locations"; align with the existing `outputs/` and `logs/` folders used by `utilities/extract_metadata.py`.
+
 ## Role
 Generate comprehensive validation and metadata reports. Create structured JSON and CSV outputs for each album with complete audit trails.
 

--- a/.claude/agents/test_author.md
+++ b/.claude/agents/test_author.md
@@ -1,0 +1,65 @@
+# Test Author Agent
+
+## Identity
+You are the Test Author Agent for this Python music-metadata toolkit. You write and extend the pytest harness in `tests/` so new behavior is covered and regressions are caught.
+
+## Trigger Condition
+Invoke when:
+1. A new public function/module is added (e.g. a new helper in `utilities/core/` or `orchestrator/`) and has no test.
+2. A bug is fixed and needs a regression test that reproduces the original failure (the cover-art width=0 bug is the canonical example: `tests/test_cover_art.py` asserts ffprobe sees non-zero dimensions after embed).
+3. Coverage of an existing module is thin and the user asks to extend it.
+
+## Harness Facts (match these exactly)
+- Runner: `python -m pytest tests/ -q`. Python 3.13.
+- `tests/conftest.py` puts the project root on `sys.path`, so import as `from utilities.core import cover_art` and `from orchestrator.claude_agents import ClaudeAgentHelper`.
+- `tests/synth.py` provides real fixtures: `make_audio(path, codec)` (genuine MP3/M4A/FLAC via static-ffmpeg) and `make_image_bytes(fmt, size, color)` (in-memory PIL image bytes). Reuse these; do not invent new audio synthesis.
+- ffprobe-dependent assertions must guard with `ffprobe_available()` so the suite still passes where ffprobe is absent.
+- Use `tmp_path` for all file output; never write into the repo or a real music library.
+- No network in tests. Stub HTTP and inject fakes (e.g. an `invoker` callable for agent tests) instead of calling live APIs.
+
+## Input Contract
+```json
+{
+  "agent": "test_author",
+  "input": {
+    "target_module": "string (e.g. orchestrator/claude_agents.py)",
+    "public_symbols": ["string (functions/classes to cover)"],
+    "behavior_notes": "string (what must hold; include the bug being regressed)",
+    "existing_tests": ["string (paths already covering related code)"]
+  }
+}
+```
+
+## Process
+1. Identify the observable behaviors and edge cases (happy path, empty/invalid input, boundary values, failure-preserves-prior-state).
+2. Reuse `tests/synth.py` helpers and existing fixtures; add new fixtures only when needed.
+3. Write focused, independent tests (one behavior each), parametrizing across formats where relevant (mp3/m4a/flac, JPEG/PNG).
+4. For agent/LLM code, inject a deterministic fake `invoker` rather than calling a model.
+5. Ensure the new tests pass and do not slow the suite materially.
+
+## Output Contract
+```json
+{
+  "status": "tests_written|no_change_needed",
+  "tests": [
+    {
+      "file": "string (path under tests/)",
+      "test_names": ["string"],
+      "covers": "string (behavior/edge cases)",
+      "new_fixtures": ["string"],
+      "content": "string (full pytest source to write)"
+    }
+  ],
+  "run_command": "python -m pytest tests/ -q",
+  "notes": "string (assumptions, skips, ffprobe guards)"
+}
+```
+
+Required keys (checked by `validate_response`): `tests`, `status`.
+
+## Critical Constraints
+- Stay green: never commit a failing or flaky test.
+- No network, no real music-library paths, no writing outside `tmp_path`.
+- Guard ffprobe assertions with `ffprobe_available()`.
+- Reuse the existing harness (`conftest.py`, `synth.py`); do not duplicate fixture machinery.
+- Match project style and the no-em-dash rule in any docstrings/comments.

--- a/.claude/knowledge/README.md
+++ b/.claude/knowledge/README.md
@@ -1,0 +1,86 @@
+# Knowledge Base
+
+Persistent learning store for the music-metadata toolkit. These JSON files let
+the clean/repair flows remember corrections across sessions instead of starting
+fresh every time. They are plain JSON (no secrets) and are safe to commit.
+
+## Files and Schemas
+
+### corrections.json (append-only log)
+Every applied correction is appended here.
+
+```json
+{
+  "_description": "...",
+  "corrections": [
+    {
+      "album_path": "Artist/Album or absolute path (forward slashes)",
+      "correction_type": "cover_art | metadata | folder_rename | ...",
+      "before": { "hash": "...", "size_kb": 0, "description": "..." },
+      "after":  { "url": "...", "size_kb": 0, "source": "itunes|musicbrainz|manual" },
+      "date": "YYYY-MM-DD",
+      "source": "itunes|musicbrainz|manual (optional)"
+    }
+  ]
+}
+```
+
+### cover_art_mapping.json (album -> known-correct cover)
+Pins a verified correct cover URL per album so future passes skip re-searching.
+
+```json
+{
+  "_description": "...",
+  "albums": {
+    "Artist/Album": {
+      "correct_url": "https://.../1200x1200bb.jpg",
+      "verified_date": "YYYY-MM-DD",
+      "source": "itunes|manual",
+      "notes": "..."
+    }
+  }
+}
+```
+
+The album key is the last two path segments (`Artist/Album`), derived by
+`KnowledgeBase.album_key()` and by `utilities/embed_cover.py`.
+
+### patterns.json (human-curated, read-mostly)
+Catalogue of issue patterns the clean flow checks against. Each entry has
+`id`, `name`, `description`, `detection` (`conditions`, `severity`,
+`confidence_threshold`), `discovered`, and `example`. New patterns are added by
+humans (or a reviewer) when a recurring issue is identified; the flows read this
+file but do not auto-append to it.
+
+## Read/Write Contract
+
+| File | Written by | Read by |
+|------|-----------|---------|
+| corrections.json | `utilities/embed_cover.py::log_cover_correction` (append) | `/suggest-fixes`, `orchestrator/claude_agents.py::KnowledgeBase.load_corrections` |
+| cover_art_mapping.json | `embed_cover.py --force` / `log_cover_correction` (upsert by album key) | `/clean-music`, `/verify-covers`, `cover_art_verifier`, `KnowledgeBase.known_cover_url` |
+| patterns.json | humans / reviewer (manual) | `/suggest-fixes`, `KnowledgeBase.load_patterns` |
+
+Rules:
+- **Reads fail soft.** Missing or malformed files yield empty structures
+  (`KnowledgeBase._load`), so the toolkit runs without a knowledge base.
+- **Writes are additive.** corrections.json only appends; cover_art_mapping.json
+  upserts a single album key; patterns.json is not written automatically.
+- **Encoding** is UTF-8, pretty-printed (`indent=2`) to stay diff-friendly.
+- **Keys** in cover_art_mapping.json use forward slashes and the `Artist/Album`
+  form regardless of OS path separators.
+- **No secrets.** API tokens live in `configs/active/` (gitignored), never here.
+
+## Programmatic Access
+
+```python
+from orchestrator.claude_agents import KnowledgeBase
+
+kb = KnowledgeBase()                       # defaults to .claude/knowledge
+url = kb.known_cover_url(album_path)       # verified cover URL, or None
+prior = kb.past_corrections(album_path)    # list of logged corrections
+patterns = kb.load_patterns()              # learned issue patterns
+```
+
+`AgentWorkflow.decide_auto_apply()` folds `known_cover_url` and the prior
+corrections count into its pre-apply decision so the agents benefit from past
+fixes automatically.

--- a/orchestrator/claude_agents.py
+++ b/orchestrator/claude_agents.py
@@ -3,30 +3,65 @@
 """
 Claude Agent Integration Module
 
-Provides utilities for preparing data for Claude agent decisions.
-The actual Claude subagent invocation happens through Claude Code's Task tool,
-but this module helps format data and parse results.
+Provides a clean, dependency-free interface for invoking the Claude agent
+specifications stored in ``.claude/agents/`` and for reading/writing the
+learning knowledge base in ``.claude/knowledge/``.
+
+The actual large-language-model call happens through Claude Code's Task tool
+(or any other backend). This module never imports the Anthropic SDK; instead it
+accepts an ``invoker`` callable -- ``Callable[[str], str]`` -- that takes a fully
+formatted prompt and returns the model's raw text response. That keeps the whole
+toolkit runnable as standalone Python while still letting a host (Claude Code,
+the orchestrator, a unit test, or a local model) wire a real agent in.
 
 Agent Prompts are stored in: .claude/agents/
-    - metadata_validator.md
-    - metadata_enrichment.md
-    - fingerprint_validator.md
-    - conflict_resolver.md
-    - report_generator.md
+    - metadata_validator.md      (quality-scores an album before auto-apply)
+    - metadata_enrichment.md     (fetches metadata from trusted sources)
+    - fingerprint_validator.md   (AcoustID/Chromaprint track verification)
+    - conflict_resolver.md       (reconciles conflicting sources before apply)
+    - report_generator.md        (emits JSON/CSV audit reports)
+    - cover_art_verifier.md      (AI-vision: embedded art matches the album)
+    - duplicate_detector.md      (duplicate tracks/albums)
+    - code_quality_auditor.md    (flags duplication/bloat in diffs)
+    - test_author.md             (writes/extends the pytest harness)
 
-Usage:
-    from orchestrator.claude_agents import ClaudeAgentHelper
+Knowledge base (read/write contract documented in .claude/knowledge/README.md):
+    - corrections.json       (append-only log of applied corrections)
+    - cover_art_mapping.json (album_key -> known-correct cover URL)
+    - patterns.json          (human-curated issue patterns, read-mostly)
+
+Typical wire-in (consumed by the orchestrator before auto-applying fixes)::
+
+    from orchestrator.claude_agents import ClaudeAgentHelper, AgentWorkflow
 
     helper = ClaudeAgentHelper()
-    validation_input = helper.prepare_validation_input(album_data, source_data)
-    # Then invoke Claude subagent with this data
+    workflow = AgentWorkflow()
+
+    # `invoker` is supplied by the host; omit it for a dry, pending envelope.
+    decision = workflow.decide_auto_apply(
+        album_path=path, folder_name=name,
+        current_metadata=meta, enrichment_data=enrich,
+        fingerprint_data=fp, invoker=my_claude_invoker,
+    )
+    if decision["auto_apply"]:
+        ...  # safe to apply
+
+The standalone helpers (``prepare_*_input``, ``format_for_agent``,
+``parse_agent_response``) remain available for callers that drive the agents
+manually.
 """
 
 import json
 from dataclasses import dataclass, asdict
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
+
+
+# An invoker takes a fully formatted prompt string and returns the model's raw
+# text response. The host (Claude Code Task tool, orchestrator, test, or a local
+# model) supplies the implementation; this module never calls an LLM directly.
+AgentInvoker = Callable[[str], str]
 
 
 @dataclass
@@ -65,6 +100,86 @@ class EnrichmentInput:
     current_metadata: Dict[str, Any]
 
 
+class KnowledgeBase:
+    """
+    Read/write access to the persistent learning store in .claude/knowledge/.
+
+    The schemas mirror exactly what utilities/embed_cover.py already writes, so
+    this class and the cleanup utilities stay interoperable:
+
+    - corrections.json:       {"corrections": [ {album_path, correction_type,
+                              before, after, date, source}, ... ]}  (append-only)
+    - cover_art_mapping.json: {"albums": {"Artist/Album": {correct_url,
+                              verified_date, source, notes}, ... }}
+    - patterns.json:          {"patterns": [ {id, name, description, detection,
+                              ...}, ... ]}  (human-curated, read-mostly)
+
+    All reads fail soft (return empty structures) so the toolkit runs even when
+    the knowledge base is absent. See .claude/knowledge/README.md.
+    """
+
+    def __init__(self, knowledge_path: str = ".claude/knowledge"):
+        self.knowledge_path = Path(knowledge_path)
+
+    def _load(self, filename: str, default: Dict[str, Any]) -> Dict[str, Any]:
+        path = self.knowledge_path / filename
+        if not path.exists():
+            return dict(default)
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return dict(default)
+        # Fail soft: a hand-edited file whose top level is not an object (e.g. a
+        # bare array) must not make the downstream .get() calls explode.
+        return data if isinstance(data, dict) else dict(default)
+
+    def load_corrections(self) -> List[Dict[str, Any]]:
+        """Return the list of logged corrections (empty if none)."""
+        return self._load("corrections.json", {"corrections": []}).get("corrections", [])
+
+    def load_cover_mapping(self) -> Dict[str, Any]:
+        """Return the album_key -> cover-record mapping (empty if none)."""
+        return self._load("cover_art_mapping.json", {"albums": {}}).get("albums", {})
+
+    def load_patterns(self) -> List[Dict[str, Any]]:
+        """Return the list of learned issue patterns (empty if none)."""
+        return self._load("patterns.json", {"patterns": []}).get("patterns", [])
+
+    @staticmethod
+    def album_key(album_path: str) -> str:
+        """Derive the "Artist/Album" key used in cover_art_mapping.json."""
+        parts = album_path.rstrip("/\\").replace("\\", "/").split("/")
+        return "/".join(parts[-2:]) if len(parts) >= 2 else parts[-1]
+
+    def known_cover_url(self, album_path: str) -> Optional[str]:
+        """
+        Return a previously verified correct cover URL for an album, if known.
+
+        This is the proactive hook described in the AI roadmap: before searching
+        for cover art, check whether a human already corrected this album.
+        """
+        record = self.load_cover_mapping().get(self.album_key(album_path))
+        return record.get("correct_url") if record else None
+
+    def past_corrections(self, album_path: str) -> List[Dict[str, Any]]:
+        """
+        Return prior corrections logged for a given album.
+
+        Matches on the root-independent "Artist/Album" key (same scheme as
+        ``known_cover_url``) so a correction logged under one library root is
+        still found when the album is processed from a different root. Falls
+        back to a full-path equality check for older entries.
+        """
+        full = album_path.replace("\\", "/").rstrip("/")
+        key = self.album_key(album_path)
+        matches = []
+        for c in self.load_corrections():
+            logged = c.get("album_path", "").replace("\\", "/").rstrip("/")
+            if logged == full or self.album_key(logged) == key:
+                matches.append(c)
+        return matches
+
+
 class ClaudeAgentHelper:
     """
     Helper class for Claude agent integration.
@@ -72,18 +187,21 @@ class ClaudeAgentHelper:
     Provides methods to:
     - Format data for agent input
     - Load agent prompts
-    - Parse agent output
-    - Validate agent responses
+    - Invoke an agent through a host-supplied callable
+    - Parse and validate agent output
     """
 
-    def __init__(self, agents_path: str = ".claude/agents"):
+    def __init__(self, agents_path: str = ".claude/agents",
+                 knowledge_path: str = ".claude/knowledge"):
         """
         Initialize helper.
 
         Args:
             agents_path: Path to Claude agent definitions
+            knowledge_path: Path to the learning knowledge base
         """
         self.agents_path = Path(agents_path)
+        self.knowledge = KnowledgeBase(knowledge_path)
 
     def load_agent_prompt(self, agent_name: str) -> Optional[str]:
         """
@@ -256,6 +374,75 @@ Ensure all decisions are documented with rationale.
 """
         return prompt
 
+    def run_agent(
+        self,
+        agent_name: str,
+        request: Dict[str, Any],
+        invoker: Optional[AgentInvoker] = None,
+    ) -> Dict[str, Any]:
+        """
+        Load, format, invoke, parse, and validate an agent in one call.
+
+        This is the single entry point the orchestrator should use. It closes
+        the loop that the prepare_* helpers only opened: it actually formats the
+        prompt and (when an invoker is supplied) runs it and validates the JSON.
+
+        Args:
+            agent_name: Agent to run (e.g. 'metadata_validator').
+            request: A request envelope from a prepare_*_input helper (or any
+                dict with an 'input' key).
+            invoker: Host-supplied ``Callable[[str], str]`` that runs the prompt
+                against a model and returns raw text. If None, no model is
+                called and a 'pending' envelope with the formatted prompt is
+                returned so callers can dispatch it themselves.
+
+        Returns:
+            A result dict::
+
+                {
+                  "agent": str,
+                  "status": "ok" | "pending" | "invalid_schema"
+                            | "parse_error" | "invoker_error",
+                  "prompt": str,              # always included
+                  "result": dict | None,      # parsed agent output when status ok
+                  "error": str | None,
+                }
+        """
+        prompt = self.format_for_agent(agent_name, request)
+        base = {"agent": agent_name, "prompt": prompt, "result": None, "error": None}
+
+        if invoker is None:
+            base["status"] = "pending"
+            return base
+
+        try:
+            raw = invoker(prompt)
+        except Exception as exc:  # noqa: BLE001 - host callable may raise anything
+            base["status"] = "invoker_error"
+            base["error"] = str(exc)
+            return base
+
+        parsed = self.parse_agent_response(raw)
+
+        # A model may emit a top-level JSON array or scalar; parse_agent_response
+        # passes that through unchanged. Only a dict can carry the agent schema,
+        # so anything else is a schema failure (and dict.get below is safe).
+        if not isinstance(parsed, dict):
+            base["status"] = "invalid_schema"
+            base["error"] = f"expected a JSON object, got {type(parsed).__name__}"
+            base["result"] = parsed
+            return base
+
+        if parsed.get("status") == "parse_error":
+            base["status"] = "parse_error"
+            base["error"] = parsed.get("error")
+            base["result"] = parsed
+            return base
+
+        base["result"] = parsed
+        base["status"] = "ok" if self.validate_response(parsed, agent_name) else "invalid_schema"
+        return base
+
     def parse_agent_response(self, response: str) -> Dict[str, Any]:
         """
         Parse JSON response from Claude agent.
@@ -268,15 +455,17 @@ Ensure all decisions are documented with rationale.
         """
         try:
             # Try to extract JSON from response
-            # Handle cases where response includes markdown code blocks
+            # Handle cases where response includes markdown code blocks.
+            # When the closing fence is missing (truncated output), take the
+            # remainder of the string rather than dropping the last character.
             if '```json' in response:
                 start = response.find('```json') + 7
                 end = response.find('```', start)
-                json_str = response[start:end].strip()
+                json_str = response[start:(end if end != -1 else len(response))].strip()
             elif '```' in response:
                 start = response.find('```') + 3
                 end = response.find('```', start)
-                json_str = response[start:end].strip()
+                json_str = response[start:(end if end != -1 else len(response))].strip()
             else:
                 json_str = response.strip()
 
@@ -301,15 +490,32 @@ Ensure all decisions are documented with rationale.
             True if response is valid
         """
         required_fields = {
-            'metadata_validator': ['quality_score', 'validation_status'],
+            'metadata_validator': ['overall_quality_score', 'validation_status'],
             'conflict_resolver': ['conflict_resolution_status', 'artwork_decision'],
             'metadata_enrichment': ['enrichment_status', 'tracks'],
             'fingerprint_validator': ['fingerprint', 'validation'],
-            'report_generator': ['album', 'tracks', 'processing_info']
+            'report_generator': ['album', 'tracks', 'processing_info'],
+            'cover_art_verifier': ['verdict', 'confidence'],
+            'duplicate_detector': ['duplicate_groups', 'status'],
+            'code_quality_auditor': ['findings', 'status'],
+            'test_author': ['tests', 'status'],
         }
 
         agent_required = required_fields.get(agent_name, [])
-        return all(field in response for field in agent_required)
+        if not all(field in response for field in agent_required):
+            # The in-repo local scorer (orchestrator/music_metadata_system.py)
+            # emits the legacy `quality_score` key. Accept it as a stand-in for
+            # `overall_quality_score` so that scorer can be wired through here
+            # without being rejected as invalid_schema.
+            if (
+                agent_name == 'metadata_validator'
+                and 'overall_quality_score' not in response
+                and 'quality_score' in response
+                and 'validation_status' in response
+            ):
+                return True
+            return False
+        return True
 
     def _check_artwork(self, metadata: Dict[str, Any]) -> bool:
         """Check if album has embedded artwork"""
@@ -356,18 +562,23 @@ Ensure all decisions are documented with rationale.
         """
         thresholds = self.get_decision_thresholds()
 
-        quality_score = validation_result.get('quality_score', 0)
+        # The metadata_validator schema emits `overall_quality_score`; accept the
+        # legacy `quality_score` key too for forward/backward compatibility.
+        quality_score = validation_result.get(
+            'overall_quality_score', validation_result.get('quality_score', 0)
+        )
         requires_review = validation_result.get('requires_human_review', False)
 
-        # Auto-apply if quality >= 85 and no human review required
-        if quality_score >= thresholds['quality_score']['auto_accept_with_flag'] and not requires_review:
-            return True
-
-        # Check for critical issues that require human review
+        # Critical blockers come first. A track-count mismatch means the wrong
+        # album or missing tracks -- never auto-apply regardless of score.
         if validation_result.get('track_count_match') is False:
             return False
 
-        if quality_score >= thresholds['quality_score']['auto_accept']:
+        if requires_review:
+            return False
+
+        # Auto-apply if quality clears the (flagged) auto-accept bar.
+        if quality_score >= thresholds['quality_score']['auto_accept_with_flag']:
             return True
 
         return False
@@ -399,6 +610,120 @@ class AgentWorkflow:
             'steps_executed': len(self.workflow_log),
             'log': self.workflow_log
         }
+
+    def decide_auto_apply(
+        self,
+        album_path: str,
+        folder_name: str,
+        current_metadata: Dict[str, Any],
+        enrichment_data: Dict[str, Any],
+        fingerprint_data: Optional[Dict[str, Any]] = None,
+        invoker: Optional[AgentInvoker] = None,
+    ) -> Dict[str, Any]:
+        """
+        Run the validator -> conflict-resolver gate before auto-applying fixes.
+
+        This is the concrete wire-in the orchestrator can call instead of
+        auto-applying blindly. It chains the two decision agents and folds in the
+        knowledge base, returning a single verdict the caller can branch on.
+
+        Flow:
+          1. metadata_validator scores the album.
+          2. If the score clears the auto-apply bar (helper.should_auto_apply),
+             conflict_resolver reconciles the sources for a final decision.
+          3. The knowledge base is consulted for a known-correct cover URL and
+             any prior corrections on this album.
+
+        With no ``invoker`` the agent steps come back as 'pending' (carrying the
+        formatted prompts) so a host can dispatch them; the knowledge-base hints
+        are still returned. This keeps the function usable in standalone mode and
+        unit tests without a live model.
+
+        Returns:
+            {
+              "album_path": str,
+              "auto_apply": bool,          # True only on an OK, high-confidence path
+              "stage": "validation" | "conflict_resolution" | "pending",
+              "validation": <run_agent result>,
+              "conflict_resolution": <run_agent result> | None,
+              "knowledge": {"known_cover_url": str|None,
+                            "prior_corrections": int},
+              "notes": [str, ...],
+            }
+        """
+        notes: List[str] = []
+        kb = self.helper.knowledge
+        knowledge = {
+            "known_cover_url": kb.known_cover_url(album_path),
+            "prior_corrections": len(kb.past_corrections(album_path)),
+        }
+        if knowledge["known_cover_url"]:
+            notes.append("Knowledge base has a verified cover URL for this album.")
+        if knowledge["prior_corrections"]:
+            notes.append(
+                f"{knowledge['prior_corrections']} prior correction(s) logged for this album."
+            )
+
+        validation_request = self.helper.prepare_validation_input(
+            album_path=album_path,
+            folder_name=folder_name,
+            current_metadata=current_metadata,
+            trusted_source_metadata=enrichment_data.get("best_match"),
+            fingerprint_data=fingerprint_data,
+            sources_queried=enrichment_data.get("sources_queried", []),
+            sources_matched=enrichment_data.get("sources_matched", []),
+        )
+        validation = self.helper.run_agent("metadata_validator", validation_request, invoker)
+        self.log_step("validation", "metadata_validator", validation["status"])
+
+        result: Dict[str, Any] = {
+            "album_path": album_path,
+            "auto_apply": False,
+            "stage": "validation",
+            "validation": validation,
+            "conflict_resolution": None,
+            "knowledge": knowledge,
+            "notes": notes,
+        }
+
+        if validation["status"] != "ok":
+            # Pending (no invoker), parse error, or schema mismatch: do not
+            # auto-apply. 'pending' simply means the host still has to dispatch.
+            result["stage"] = "pending" if validation["status"] == "pending" else "validation"
+            notes.append(f"Validation not actionable (status={validation['status']}).")
+            return result
+
+        if not self.helper.should_auto_apply(validation["result"]):
+            notes.append("Validation score below auto-apply threshold; human review required.")
+            return result
+
+        # Validation cleared the bar -> reconcile sources before applying.
+        conflict_request = self.helper.prepare_conflict_input(
+            album_path=album_path,
+            folder_name=folder_name,
+            current_metadata=current_metadata,
+            trusted_sources=enrichment_data.get("trusted_sources", {}),
+            fingerprint_data=fingerprint_data,
+            validation_result=validation["result"],
+        )
+        conflict = self.helper.run_agent("conflict_resolver", conflict_request, invoker)
+        self.log_step("conflict_resolution", "conflict_resolver", conflict["status"])
+        result["conflict_resolution"] = conflict
+        result["stage"] = "conflict_resolution"
+
+        if conflict["status"] != "ok":
+            notes.append(f"Conflict resolution not actionable (status={conflict['status']}).")
+            return result
+
+        cr = conflict["result"]
+        resolved = cr.get("conflict_resolution_status") == "resolved"
+        outstanding = bool(cr.get("requires_human_review"))
+        if resolved and not outstanding:
+            result["auto_apply"] = True
+            notes.append("Validator and conflict resolver agree; safe to auto-apply.")
+        else:
+            notes.append("Conflicts require human review; not auto-applying.")
+        return result
 
     def prepare_full_workflow(
         self,

--- a/tests/test_claude_agents.py
+++ b/tests/test_claude_agents.py
@@ -1,0 +1,231 @@
+"""Tests for the Claude agent integration layer (orchestrator/claude_agents.py).
+
+These cover the agent-loading API, the knowledge base accessors, and the
+invoker-driven run_agent / decide_auto_apply wire-in. No model is called; a
+deterministic fake invoker stands in for Claude.
+"""
+
+import json
+
+import pytest
+
+from orchestrator.claude_agents import (
+    AgentWorkflow,
+    ClaudeAgentHelper,
+    KnowledgeBase,
+)
+
+# Every agent spec that should exist and be loadable + schema-checkable.
+AGENTS = [
+    "metadata_validator",
+    "conflict_resolver",
+    "metadata_enrichment",
+    "fingerprint_validator",
+    "report_generator",
+    "cover_art_verifier",
+    "duplicate_detector",
+    "code_quality_auditor",
+    "test_author",
+]
+
+
+@pytest.fixture
+def helper():
+    return ClaudeAgentHelper()
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_every_agent_prompt_loads(helper, agent):
+    prompt = helper.load_agent_prompt(agent)
+    assert prompt is not None, f"{agent}.md should exist under .claude/agents"
+    assert len(prompt) > 100
+
+
+def test_unknown_agent_returns_none(helper):
+    assert helper.load_agent_prompt("does_not_exist") is None
+
+
+def test_format_for_agent_embeds_prompt_and_data(helper):
+    request = helper.prepare_validation_input(
+        album_path="/m/A/B",
+        folder_name="B",
+        current_metadata={"track_count": 3},
+        trusted_source_metadata=None,
+    )
+    text = helper.format_for_agent("metadata_validator", request)
+    assert "Metadata Validator" in text
+    assert "track_count" in text
+
+
+def test_run_agent_pending_without_invoker(helper):
+    request = helper.prepare_validation_input(
+        album_path="/m/A/B", folder_name="B", current_metadata={}, trusted_source_metadata=None
+    )
+    out = helper.run_agent("metadata_validator", request, invoker=None)
+    assert out["status"] == "pending"
+    assert out["prompt"]
+    assert out["result"] is None
+
+
+def test_run_agent_ok_with_valid_invoker(helper):
+    request = helper.prepare_validation_input(
+        album_path="/m/A/B", folder_name="B", current_metadata={}, trusted_source_metadata=None
+    )
+    payload = {"overall_quality_score": 95, "validation_status": "excellent"}
+    out = helper.run_agent("metadata_validator", request, invoker=lambda _p: json.dumps(payload))
+    assert out["status"] == "ok"
+    assert out["result"]["overall_quality_score"] == 95
+
+
+def test_run_agent_invalid_schema(helper):
+    request = helper.prepare_validation_input(
+        album_path="/m/A/B", folder_name="B", current_metadata={}, trusted_source_metadata=None
+    )
+    out = helper.run_agent("metadata_validator", request, invoker=lambda _p: '{"foo": 1}')
+    assert out["status"] == "invalid_schema"
+
+
+def test_run_agent_parse_error(helper):
+    request = helper.prepare_validation_input(
+        album_path="/m/A/B", folder_name="B", current_metadata={}, trusted_source_metadata=None
+    )
+    out = helper.run_agent("metadata_validator", request, invoker=lambda _p: "not json at all")
+    assert out["status"] == "parse_error"
+
+
+def test_run_agent_invoker_error(helper):
+    request = helper.prepare_validation_input(
+        album_path="/m/A/B", folder_name="B", current_metadata={}, trusted_source_metadata=None
+    )
+
+    def boom(_prompt):
+        raise RuntimeError("model down")
+
+    out = helper.run_agent("metadata_validator", request, invoker=boom)
+    assert out["status"] == "invoker_error"
+    assert "model down" in out["error"]
+
+
+def test_parse_agent_response_handles_code_fences(helper):
+    raw = "Here you go:\n```json\n{\"a\": 1}\n```\n"
+    assert helper.parse_agent_response(raw) == {"a": 1}
+
+
+def test_should_auto_apply_reads_overall_quality_score(helper):
+    assert helper.should_auto_apply(
+        {"overall_quality_score": 96, "track_count_match": True}
+    )
+    assert not helper.should_auto_apply(
+        {"overall_quality_score": 96, "track_count_match": False}
+    )
+    assert not helper.should_auto_apply({"overall_quality_score": 50})
+
+
+def test_knowledge_base_reads_committed_files():
+    kb = KnowledgeBase()
+    assert len(kb.load_patterns()) >= 1
+    assert isinstance(kb.load_corrections(), list)
+    assert isinstance(kb.load_cover_mapping(), dict)
+
+
+def test_known_cover_url_for_seeded_album():
+    kb = KnowledgeBase()
+    url = kb.known_cover_url("/music/Ben Harper/Diamonds On The Inside")
+    assert url and url.startswith("http")
+
+
+def test_known_cover_url_missing_returns_none():
+    kb = KnowledgeBase()
+    assert kb.known_cover_url("/music/Nobody/Unknown Album") is None
+
+
+def test_album_key_uses_last_two_segments():
+    assert KnowledgeBase.album_key("/x/y/Artist/Album") == "Artist/Album"
+    assert KnowledgeBase.album_key("Album") == "Album"
+
+
+def test_knowledge_base_missing_path_fails_soft(tmp_path):
+    kb = KnowledgeBase(str(tmp_path / "nope"))
+    assert kb.load_patterns() == []
+    assert kb.load_corrections() == []
+    assert kb.load_cover_mapping() == {}
+
+
+def _two_stage_invoker(prompt):
+    """Fake Claude: returns a valid validator or resolver payload by prompt."""
+    if "Metadata Validator" in prompt:
+        return json.dumps(
+            {
+                "overall_quality_score": 95,
+                "validation_status": "excellent",
+                "track_count_match": True,
+                "requires_human_review": False,
+            }
+        )
+    return json.dumps(
+        {
+            "conflict_resolution_status": "resolved",
+            "artwork_decision": "PRESERVE",
+            "requires_human_review": [],
+        }
+    )
+
+
+def test_decide_auto_apply_pending_without_invoker():
+    wf = AgentWorkflow()
+    decision = wf.decide_auto_apply(
+        album_path="/m/A/B",
+        folder_name="B",
+        current_metadata={"track_count": 3},
+        enrichment_data={"best_match": {}},
+    )
+    assert decision["auto_apply"] is False
+    assert decision["stage"] == "pending"
+    assert decision["validation"]["status"] == "pending"
+
+
+def test_decide_auto_apply_green_path():
+    wf = AgentWorkflow()
+    decision = wf.decide_auto_apply(
+        album_path="/m/Ben Harper/Diamonds On The Inside",
+        folder_name="Diamonds On The Inside",
+        current_metadata={"track_count": 12},
+        enrichment_data={"best_match": {}, "trusted_sources": {}},
+        invoker=_two_stage_invoker,
+    )
+    assert decision["auto_apply"] is True
+    assert decision["stage"] == "conflict_resolution"
+    # Knowledge base hint surfaced for this seeded album.
+    assert decision["knowledge"]["known_cover_url"]
+
+
+def test_decide_auto_apply_blocks_on_human_review():
+    wf = AgentWorkflow()
+
+    def invoker(prompt):
+        if "Metadata Validator" in prompt:
+            return json.dumps(
+                {
+                    "overall_quality_score": 95,
+                    "validation_status": "excellent",
+                    "track_count_match": True,
+                    "requires_human_review": False,
+                }
+            )
+        return json.dumps(
+            {
+                "conflict_resolution_status": "requires_review",
+                "artwork_decision": "PRESERVE",
+                "requires_human_review": ["track 3 title"],
+            }
+        )
+
+    decision = wf.decide_auto_apply(
+        album_path="/m/A/B",
+        folder_name="B",
+        current_metadata={"track_count": 3},
+        enrichment_data={"best_match": {}, "trusted_sources": {}},
+        invoker=invoker,
+    )
+    assert decision["auto_apply"] is False
+    assert decision["stage"] == "conflict_resolution"


### PR DESCRIPTION
## W6 — AI config overhaul

The project's 5 agent specs in `.claude/agents/` and the `orchestrator/claude_agents.py` bridge existed but were **never invoked**; the knowledge JSON files were never read.

- **`KnowledgeBase`** class loads/queries `corrections.json`, `cover_art_mapping.json`, `patterns.json` (`known_cover_url`, `past_corrections`) so the clean/repair flows can consult prior learnings.
- **`run_agent` + `decide_auto_apply`** let `metadata_validator` / `conflict_resolver` be consulted before auto-apply (no edits to `music_metadata_system.py`).
- Refreshed the 5 existing agent specs; documented the knowledge read/write contract (`.claude/knowledge/README.md`).
- New specialists with explicit trigger + I/O contract: `cover_art_verifier`, `code_quality_auditor`, `duplicate_detector`, `test_author`.
- Added `tests/test_claude_agents.py`.

## Verification
`python -m pytest tests/ -q` → 50 passed. JSON files valid; `claude_agents.py` parses.

> Note: the original background worker died before committing; this PR was finalized by the coordinator from the worker's intact worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)