### PR TITLE
feat(cover-art): validated folder.jpg generator + repo hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ logs/
 # Generated outputs (reports, audits)
 outputs/
 
+# Per-run working data / personal library reports (album lists, candidate
+# manifests, audit reports). May contain library paths/host info - never commit.
+issues/
+
 # Python
 __pycache__/
 *.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,9 @@ D:\music cleanup\
 │   ├── fix_metadata.py         # Single-file metadata fixes
 │   ├── batch_fix_metadata.py   # Batch metadata operations
 │   ├── embed_cover.py          # Cover art embedding
+│   ├── generate_folder_art.py  # Write folder.jpg from embedded art (additive)
+│   ├── repair_covers.py        # Re-fetch/re-embed corrupt or wrong covers
+│   ├── core/                   # Validated cover-art pipeline (cover_art, ffprobe, ...)
 │   └── consolidate_multidisc.py# Multi-disc consolidation
 │
 ├── configs/                    # YAML configurations
@@ -464,6 +467,40 @@ previously "valid-looking" files. Background and rationale:
 > See project memory: `C:\Users\Admin\.claude\projects\D--music-cleanup\memory\cover-art-validation.md`
 > and `C:\Users\Admin\.claude\projects\D--music-cleanup\memory\jellyfin-ffprobe-truth.md` (indexed in MEMORY.md).
 
+### generate_folder_art.py (folder.jpg from embedded art)
+
+**Purpose:** create a `folder.jpg` / `folder.png` (the image Jellyfin and most
+scanners prefer for album art) for albums that have valid *embedded* art but no
+folder image. Reads embedded art only; never modifies audio files.
+
+**Safety contract (additive + non-regressing):**
+- Writes ONLY where no `folder.jpg`/`cover.jpg`/`front.jpg` exists; exclusive
+  create (`open(..., 'xb')`) so a concurrently-created image is never overwritten.
+- Validates each image via `core.cover_art.validate_image` (magic bytes + Pillow
+  decode + dims>0) AND confirms it is ffmpeg-readable via
+  `core.ffprobe.attached_pic_dims` before writing; non-JPEG/PNG or
+  ffmpeg-unreadable art is salvaged by re-encoding to a clean JPEG.
+- Post-write read-back re-probes the saved file; a truncated/corrupt write is
+  deleted and reported (never logged as success).
+- Degrades gracefully when ffprobe/`static-ffmpeg` is unavailable (falls back to a
+  Pillow decode check) instead of failing every album.
+- Scans all tracks for embedded art (not just track 1); extension matches the
+  detected content (`folder.png` for PNG bytes). Per-album fail-soft; created
+  paths are appended to `outputs/folderjpg_created.log` for undo.
+
+```bash
+# Preview which albums are missing a folder image (no reads of art, no writes)
+python utilities/generate_folder_art.py "/path/to/Music" --scan-only
+
+# Validate every candidate's embedded art (writes nothing)
+python utilities/generate_folder_art.py "/path/to/Music" --dry-run
+
+# Write the folder image where missing (additive, logged)
+python utilities/generate_folder_art.py "/path/to/Music" --execute
+```
+
+> Method/rationale in project memory: `cover-remediation-method.md` (indexed in MEMORY.md).
+
 ---
 
 ## YAML Configuration System
@@ -757,6 +794,26 @@ if not os.path.exists(kb_path):
 
 ## Changelog
 
+### 2026-06-28 (Full-library cover sweep + folder.jpg generator)
+- **Library-wide cover remediation**: validated/repaired covers across the whole
+  library; missing-art list driven from 137 to 0. Wrong-but-unfindable covers were
+  blanked (art backed up); branded/soundtrack covers recovered via iTunes → Discogs
+  API → MusicBrainz Cover Art Archive; many albums retitled to match the actual CD.
+  Method captured in project memory `cover-remediation-method.md`.
+- **New `utilities/generate_folder_art.py`**: additive generator that writes
+  `folder.jpg`/`folder.png` from each album's validated embedded art for albums that
+  lacked a folder image (600 generated). Additive-only (never overwrites), no audio
+  writes, validates + ffmpeg-verifies before and after write, graceful ffprobe
+  fallback. Hardened per code review (exclusive create, post-write read-back,
+  all-tracks art scan, salvage re-encode, per-process temp, fail-soft + undo log).
+- **Repo hygiene (public)**: `issues/` (per-run working data: album lists, candidate
+  manifests, audit reports) added to `.gitignore`; private host IP scrubbed from
+  tooling. Secrets scan clean - no tokens/keys/emails in tracked files.
+- **Backups cleanup**: removed 795 redundant in-album `backups/` folders (~39 GB
+  reclaimed) after verifying every backed-up song was present in its album.
+- **Eradicated the last `width=0`**: one album with a malformed APIC (Pillow-OK but
+  ffmpeg 0x0) re-embedded through the validated core; library now 100% ffprobe-clean.
+
 ### 2026-06-27 (Docs slim + cover-art core)
 - **Slimmed CLAUDE.md**: Moved large reference sections (Lessons Learned, U2
   Case Study, Best Practices, Multi-Disc background, Naming Conventions, Common
@@ -951,8 +1008,8 @@ python -c "import os; os.rename('old.mp3', 'new.mp3')"
 
 ---
 
-**Last Updated:** 2026-06-27
+**Last Updated:** 2026-06-28
 **Project Status:** Active Development (v4.0)
-**Current Focus:** Various Artists folder organization and cleanup (273 albums, 4,762 tracks)
-**Completed:** U2 library (261 tracks), Various Artists folder reorganization (Holiday/Soundtracks), Project refactoring
-**Next Target:** Full music library expansion
+**Current Focus:** Full-library maintenance - covers validated 100% (1,636 albums / 15,860 tracks), folder.jpg coverage 100%, 0 width=0
+**Completed:** U2 library (261 tracks), full-library cover remediation (missing-art 137 to 0), folder.jpg generator, 795 backups folders reclaimed (~39 GB), secrets/repo hygiene pass
+**Next Target:** Optional - per-track artist/title tagging for DJ-mix compilations; ongoing new-music intake

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ D:\music cleanup\
 │   ├── disc_consolidator.py    # Multi-disc consolidation
 │   ├── track_mover.py          # Move tracks between albums
 │   ├── embed_cover.py          # Cover art embedding
+│   ├── generate_folder_art.py  # Write folder.jpg from embedded art (additive)
+│   ├── core/                   # Validated cover-art pipeline (cover_art, ffprobe)
 │   ├── fix_metadata.py
 │   ├── batch_fix_metadata.py
 │   └── scan_folders.py
@@ -147,6 +149,22 @@ Automatically handles:
 - File renaming: `01 Track.mp3` → `1-01 Track.mp3`
 - Metadata updates: Sets `discnumber` field
 - Folder cleanup: Removes empty source folders
+
+### Validated Cover Art
+All cover/image handling routes through one validated pipeline
+(`utilities/core/cover_art.py`): magic-byte + Pillow checks plus an `ffprobe`
+ground-truth read (the same engine Jellyfin uses), with a post-write `dims > 0`
+assertion. This eliminates the `width=0`/`height=0` art Jellyfin reported.
+
+`utilities/generate_folder_art.py` creates a `folder.jpg`/`folder.png` from each
+album's validated embedded art for albums missing a folder image - **additive only**
+(never overwrites existing art), no audio writes, validated + ffmpeg-verified before
+and after write:
+```bash
+python utilities/generate_folder_art.py "/path/to/Music" --scan-only   # preview
+python utilities/generate_folder_art.py "/path/to/Music" --dry-run      # validate, no writes
+python utilities/generate_folder_art.py "/path/to/Music" --execute      # write where missing
+```
 
 ### YAML Batch Operations
 Use config files for repeatable operations:

--- a/utilities/generate_folder_art.py
+++ b/utilities/generate_folder_art.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""
+Generate folder.jpg / folder.png for albums that have valid embedded art but no
+folder image (the file Jellyfin and other scanners prefer for album art).
+
+ADDITIVE + SAFE by design:
+  - Writes a folder image ONLY to albums with no folder.jpg/cover.jpg/front.jpg.
+  - Exclusive create ('xb'): if a folder image appears concurrently it is never
+    overwritten - the album is skipped, honoring the never-overwrite contract.
+  - NEVER writes to audio files (embedded art is read-only here), so embedded-art
+    health and ffprobe width>0 cannot regress.
+  - Validates every image (magic bytes + Pillow decode + dims>0) AND confirms it is
+    ffmpeg-readable (the Jellyfin ground truth) before writing. Non-JPEG/PNG or
+    ffmpeg-unreadable art is salvaged by re-encoding to a clean JPEG via Pillow.
+  - Post-write read-back: the written file is re-probed (ffprobe dims>0, or Pillow
+    if ffprobe is unavailable); a bad/truncated write is deleted and reported.
+  - Degrades gracefully when ffprobe/static-ffmpeg is unavailable: falls back to the
+    Pillow decode check (same policy as utilities/core), rather than failing every album.
+  - The image extension matches the detected content (folder.png for PNG bytes).
+  - Per-album fail-soft: an error on one album is logged and skipped, never aborting
+    the batch. Created paths are appended to the undo log immediately.
+
+Modes:
+  --scan-only   list albums missing a folder image (no art reads, no writes)
+  --dry-run     validate each candidate's art (no writes; default)
+  --execute     write the folder image where missing
+
+Usage:
+  python utilities/generate_folder_art.py "/path/to/Music" --scan-only
+  python utilities/generate_folder_art.py "/path/to/Music" --dry-run
+  python utilities/generate_folder_art.py "/path/to/Music" --execute
+"""
+import argparse
+import os
+import stat
+import sys
+import tempfile
+from io import BytesIO
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from PIL import Image  # noqa: E402
+from utilities.core.cover_art import (  # noqa: E402
+    extract_cover_from_file,
+    validate_image,
+    detect_image_mime,
+    InvalidCoverArt,
+)
+from utilities.core.ffprobe import attached_pic_dims, ffprobe_available  # noqa: E402
+from utilities.core.audio_file import AUDIO_EXTS  # noqa: E402
+
+EXC = {'.recycle', '@eadir', '#recycle', 'backups', '.cover_backup'}
+IMG_EXT = {'.jpg', '.jpeg', '.png'}
+FOLDER_STEMS = ('folder', 'cover', 'front')
+
+
+class _Skip(Exception):
+    """Album skipped (e.g. a folder image already exists) - not a failure."""
+
+
+def excluded(root: Path, p: Path) -> bool:
+    return any(
+        x.lower() in EXC or x.startswith(('.', '@', '#'))
+        for x in p.relative_to(root).parts
+    )
+
+
+def has_folder_image(d: Path) -> bool:
+    for f in d.iterdir():
+        if f.is_file() and f.suffix.lower() in IMG_EXT and f.stem.lower() in FOLDER_STEMS:
+            return True
+    return False
+
+
+def find_missing_albums(root: Path):
+    """Album dirs (containing audio) that have no folder/cover/front image."""
+    missing = []
+    for dp, dn, fn in os.walk(root):
+        p = Path(dp)
+        if p != root and excluded(root, p):
+            dn[:] = []
+            continue
+        audio = sorted(p / n for n in fn if os.path.splitext(n)[1].lower() in AUDIO_EXTS)
+        if audio and not has_folder_image(p):
+            missing.append((p, audio))
+    return missing
+
+
+def first_embedded_art(audio_files):
+    """Return embedded art bytes from the first track that has any, else None.
+
+    Scans all tracks (not just track 1) so an album whose first-sorted track lacks
+    art but whose others have it is still covered.
+    """
+    for f in audio_files:
+        raw = extract_cover_from_file(f)
+        if raw:
+            return raw
+    return None
+
+
+def ffmpeg_image_dims(data: bytes):
+    """(w, h) that ffprobe reads from standalone image bytes, or None.
+
+    Reuses core.ffprobe.attached_pic_dims (it matches a lone mjpeg/png video
+    stream too). Uses a unique temp file per call (no shared-path race).
+    """
+    fd, tmp = tempfile.mkstemp(suffix='.img', prefix='fja_')
+    try:
+        with os.fdopen(fd, 'wb') as fh:
+            fh.write(data)
+        return attached_pic_dims(tmp)
+    finally:
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+
+
+def prepare_image(data: bytes, has_ffprobe: bool):
+    """Return (final_bytes, mime, reencoded:bool) or raise InvalidCoverArt.
+
+    Lossless fast path when the bytes already validate and are ffmpeg-readable.
+    Otherwise (unrecognized format, too-small-after-magic, or ffmpeg-unreadable)
+    salvage by re-encoding to a clean JPEG via Pillow and re-validate.
+    When ffprobe is unavailable, accept Pillow-validated bytes (graceful degrade).
+    """
+    try:
+        mime = validate_image(data)
+        valid_as_is = True
+    except InvalidCoverArt:
+        mime, valid_as_is = None, False
+
+    if valid_as_is:
+        if not has_ffprobe:
+            return data, mime, False
+        dims = ffmpeg_image_dims(data)
+        if dims and dims[0] > 0 and dims[1] > 0:
+            return data, mime, False
+
+    # Salvage path: re-encode whatever Pillow can open into a clean JPEG.
+    try:
+        im = Image.open(BytesIO(data)).convert('RGB')
+        buf = BytesIO()
+        im.save(buf, 'JPEG', quality=92)
+        reenc = buf.getvalue()
+    except Exception as exc:  # UnidentifiedImageError, OSError, MemoryError, ...
+        raise InvalidCoverArt(f'could not re-encode image: {exc}') from exc
+
+    mime2 = validate_image(reenc)  # JPEG now; still enforces dims>=MIN_DIMENSION
+    if has_ffprobe:
+        dims2 = ffmpeg_image_dims(reenc)
+        if not (dims2 and dims2[0] > 0 and dims2[1] > 0):
+            raise InvalidCoverArt('re-encoded image still not ffmpeg-readable')
+    return reenc, mime2, True
+
+
+def verify_written(dest: Path, has_ffprobe: bool) -> bool:
+    """Post-write read-back: confirm the saved file is a real, sized image."""
+    if has_ffprobe:
+        dims = attached_pic_dims(dest)
+        return bool(dims and dims[0] > 0 and dims[1] > 0)
+    try:
+        with Image.open(dest) as im:
+            im.load()
+            return im.size[0] > 0 and im.size[1] > 0
+    except Exception:
+        return False
+
+
+def write_folder_image(album: Path, data: bytes, mime: str, has_ffprobe: bool) -> Path:
+    """Exclusive-create folder.<ext>, restore any toggled dir attr, verify, return path.
+
+    Raises _Skip if a folder image already exists, InvalidCoverArt on a bad write.
+    """
+    ext = 'png' if (mime == 'image/png' or detect_image_mime(data) == 'image/png') else 'jpg'
+    dest = album / f'folder.{ext}'
+    restore = None
+    try:
+        try:
+            fh = open(dest, 'xb')
+        except FileExistsError:
+            raise _Skip(f'{dest.name} already exists')
+        except PermissionError:
+            orig_mode = os.stat(album).st_mode
+            os.chmod(album, orig_mode | stat.S_IWRITE)
+            restore = (album, orig_mode)
+            fh = open(dest, 'xb')  # may still raise FileExistsError -> propagates as skip below
+        with fh:
+            fh.write(data)
+    except FileExistsError:
+        raise _Skip(f'{dest.name} already exists')
+    finally:
+        if restore:
+            try:
+                os.chmod(restore[0], restore[1])
+            except OSError:
+                pass
+
+    if not verify_written(dest, has_ffprobe):
+        try:
+            dest.unlink()
+        except OSError:
+            pass
+        raise InvalidCoverArt('post-write verification failed (file removed)')
+    return dest
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('library', help='music library root (e.g. /path/to/Music or //SERVER/Music)')
+    mode = ap.add_mutually_exclusive_group()
+    mode.add_argument('--scan-only', action='store_true', help='list missing albums only')
+    mode.add_argument('--dry-run', action='store_true', help='validate, write nothing (default)')
+    mode.add_argument('--execute', action='store_true', help='write the folder image where missing')
+    ap.add_argument('--log', default=str(Path(__file__).resolve().parent.parent / 'outputs' / 'folderjpg_created.log'))
+    args = ap.parse_args()
+
+    root = Path(args.library.replace('\\', '/'))
+    if not root.is_dir():
+        print(f'ERROR: library not found: {root}')
+        sys.exit(2)
+
+    print(f'Scanning {root} ...', flush=True)
+    missing = find_missing_albums(root)
+    print(f'Albums missing a folder image: {len(missing)}')
+
+    if args.scan_only:
+        for p, _ in missing[:50]:
+            print('  ', p.relative_to(root))
+        if len(missing) > 50:
+            print(f'   ... and {len(missing) - 50} more')
+        return
+
+    has_ffprobe = ffprobe_available()
+    if not has_ffprobe:
+        print('NOTE: ffprobe/static-ffmpeg unavailable -> using Pillow decode check '
+              '(consumer-parity unverified).')
+
+    do_write = args.execute
+    written = reencoded = skipped = failed = 0
+    failures = []
+
+    log_fh = None
+    if do_write:
+        Path(args.log).parent.mkdir(parents=True, exist_ok=True)
+        log_fh = open(args.log, 'a', encoding='utf-8')
+
+    try:
+        for i, (album, audio) in enumerate(missing, 1):
+            try:
+                if has_folder_image(album):  # appeared since the scan
+                    skipped += 1
+                    continue
+                raw = first_embedded_art(audio)
+                if not raw:
+                    raise InvalidCoverArt('no embedded art on any track')
+                data, mime, was_reenc = prepare_image(raw, has_ffprobe)
+                if was_reenc:
+                    reencoded += 1
+                if do_write:
+                    dest = write_folder_image(album, data, mime, has_ffprobe)
+                    written += 1
+                    log_fh.write(str(dest) + '\n')
+                    log_fh.flush()
+                else:
+                    written += 1  # would-write (dry-run)
+            except _Skip:
+                skipped += 1
+            except InvalidCoverArt as exc:
+                failed += 1
+                failures.append(f'{album.relative_to(root)} :: {exc}')
+            except Exception as exc:  # never let one album abort the batch
+                failed += 1
+                failures.append(f'{album.relative_to(root)} :: unexpected: {exc}')
+            if i % 50 == 0:
+                print(f'  [{i}/{len(missing)}] {"written" if do_write else "validated"}={written} '
+                      f'reencoded={reencoded} skipped={skipped} failed={failed}', flush=True)
+    finally:
+        if log_fh:
+            log_fh.close()
+
+    print('\n===== RESULT =====')
+    verb = 'WROTE' if do_write else 'WOULD WRITE (dry-run)'
+    print(f'{verb}: {written}  | re-encoded: {reencoded}  | skipped: {skipped}  | failed: {failed}')
+    if failures:
+        print(f'\n--- failures ({len(failures)}) ---')
+        for f in failures[:40]:
+            print('  ', f)
+        if len(failures) > 40:
+            print(f'   ... and {len(failures) - 40} more')
+    if do_write and written:
+        print(f'\ncreated paths logged to: {args.log}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
Adds `utilities/generate_folder_art.py`, an **additive** generator that writes `folder.jpg`/`folder.png` from each album's validated embedded art for albums missing a folder image (the file Jellyfin and most scanners prefer). Also documents the validated cover-art pipeline and tightens repo hygiene for the public repo.

## Safety contract (non-regressing)
- **Additive only** - writes where no `folder.jpg`/`cover.jpg`/`front.jpg` exists; exclusive create (`xb`) never overwrites a concurrently-created image.
- **No audio writes** - reads embedded art only, so embedded-art health and ffprobe `width>0` cannot regress.
- **Validate + verify** - magic bytes + Pillow decode + `dims>0`, confirmed ffmpeg-readable before write, with a post-write read-back that deletes/reports a truncated write.
- **Graceful degrade** when ffprobe/`static-ffmpeg` is unavailable (Pillow decode check).
- Scans all tracks for art, salvages non-JPEG/PNG via re-encode, picks the extension from detected content, per-album fail-soft, incremental undo log.

Reuses the core pipeline (`cover_art.validate_image`/`detect_image_mime`, `ffprobe.attached_pic_dims`) rather than re-implementing validation. Hardened per an automated code review (10 findings addressed; functionally tested).

## Docs & hygiene
- CLAUDE.md + README.md: document the utility and the validated cover-art pipeline; 2026-06-28 changelog entry.
- `.gitignore`: ignore `issues/` (per-run working data); private host IP scrubbed from tooling. No secrets in tracked files.

## Validation
Run against a 1,636-album / 15,860-track library: generated 600 folder images, then a read-only re-scan confirmed 100% folder.jpg coverage, 0 `width=0`, embedded art still 100% OK (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)