### PR TITLE
fix(scan/covers): recycle-bin exclusions, folder↔embedded cover parity, off-library backups

### DIFF
--- a/.claude/commands/lifecycle.md
+++ b/.claude/commands/lifecycle.md
@@ -43,7 +43,7 @@ Run the phases in this exact order. Do not add, drop, or reorder phases.
 | 2 | identify | `ValidatorAgent.identify_unknown_tracks(...)` / AcoustID (`sources/acoustid.py`) for weak-metadata albums only | `fingerprint_validator` adjudicates which AcoustID hit to trust |
 | 3 | validate | `python cli.py validate "<path>"` (ValidatorAgent vs MusicBrainz/iTunes) | `conflict_resolver` + `fingerprint_validator` on ambiguous matches |
 | 4 | dedupe | `python cli.py dedupe "<path>" [--scan-only/--dry-run/--execute]` (`utilities/deduplicate.py`) | `duplicate_detector` adjudicates the `outputs/dedupe_review.json` list |
-| 5 | covers | `python cli.py repair-covers "<path>" [...]` then `generate_folder_art(root, execute=...)` (`utilities/generate_folder_art.py`) | `/verify-covers` visual match on embedded/folder art |
+| 5 | covers | `python cli.py repair-covers "<path>"` -> `generate_folder_art(root, execute=...)` -> `python cli.py sync-covers "<path>"` (`utilities/cover_consistency.py`, folder.jpg-authoritative perceptual parity) | `/verify-covers` visual match on the folder image |
 | 6 | fix | `python cli.py fix "<path>"` (FixerAgent; applies approved metadata/cover fixes) | applies only the decisions confirmed in phases 3-5 |
 
 The single Python entry point that chains all six is:
@@ -176,11 +176,29 @@ python -c "from utilities.generate_folder_art import generate_folder_art; print(
 
 Pass `execute=True` ONLY in confirmed execute mode; otherwise `execute=False`.
 
+Finally, reconcile embedded track art with the album folder image
+(**folder.jpg is authoritative**), so every track matches the cover shown in the
+media server:
+
+```bash
+cd "D:\music cleanup" && python cli.py sync-covers "<normalized_path>" [--scan-only|--dry-run|--execute]
+```
+
+`utilities/cover_consistency.py` validates each album's folder image (decodes +
+ffprobe `dims > 0`), compares it **perceptually** (difference hash, so a
+re-encoded/resized copy still matches) to each track's embedded art, and embeds
+the folder image into every track whose art is missing or different. Runs after
+`generate_folder_art` so a folder image exists to propagate. An invalid folder
+image is flagged, never propagated. Writes only under `--execute` (album backed
+up first; every embed goes through the validated core with an ffprobe read-back).
+
 **AI decision point — `/verify-covers`:** after art is in place (or planned),
 run the visual-match check from `/verify-covers` over the album `folder.jpg`
 files. Cover art can be technically valid (good size, full coverage) yet
-visually WRONG for the album (Ben Harper, 2026-01-13). Flag mismatches in the
-summary; re-embed a correct cover only under confirmed `--execute`.
+visually WRONG for the album (Ben Harper, 2026-01-13). The perceptual sync makes
+tracks match the folder image; `/verify-covers` is what catches a folder image
+that is itself the wrong picture. Flag mismatches in the summary; replace a
+wrong cover only under confirmed `--execute`.
 
 ### Phase 6 — fix
 

--- a/.claude/commands/lifecycle.md
+++ b/.claude/commands/lifecycle.md
@@ -94,6 +94,18 @@ cd "D:\music cleanup" && python cli.py scan "<normalized_path>"
 Extract metadata, cover presence, and issues for every album. This seeds the
 processing queue the later phases consume.
 
+**Excluded directories.** Every phase walks the library through one shared
+exclusion rule (`utilities/core/audio_file.is_excluded_dir` /
+`is_excluded_path`), so NAS recycle bins and OS/system metadata dirs are never
+scanned, validated, de-duped, or cover-checked. Skipped names include
+`.recycle`, `#recycle`, `@eaDir`, `#snapshot`, `$RECYCLE.BIN`, `System Volume
+Information`, macOS `.Trashes`/`.Spotlight-V100`/`.fseventsd`, Syncthing
+`.stfolder`/`.stversions`, and the toolkit's own `backups/`, `.cover_backup/`,
+`_duplicates/`. Real music folders that merely start with a dot or symbol
+(`.38 Special`, `...And You Will Know Us by the Trail of Dead`) are still
+scanned. Do not add ad-hoc skip logic in a phase; extend the shared set instead
+so all walkers stay in parity.
+
 ### Phase 2 — identify
 
 Best-effort AcoustID song-ID for albums with weak metadata only (no title, or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ D:\music cleanup\
 │   ├── batch_fix_metadata.py   # Batch metadata operations
 │   ├── embed_cover.py          # Cover art embedding
 │   ├── generate_folder_art.py  # Write folder.jpg from embedded art (additive)
+│   ├── cover_consistency.py    # Make tracks match folder.jpg (perceptual; folder authoritative)
 │   ├── repair_covers.py        # Re-fetch/re-embed corrupt or wrong covers
 │   ├── deduplicate.py          # Duplicate tracks -> backup (validate first; never deletes)
 │   ├── core/                   # Validated cover-art pipeline (cover_art, ffprobe, ...)
@@ -874,6 +875,21 @@ if not os.path.exists(kb_path):
 - [MusicBrainz Forums](https://community.metabrainz.org/) - Metadata best practices
 
 ## Changelog
+
+### 2026-07-02 (Cover consistency: folder.jpg <-> embedded parity)
+- **New `utilities/cover_consistency.py` + `cli.py sync-covers`**: the album
+  **folder image is authoritative**. For every album with a folder.jpg/cover/front,
+  it validates that image (Pillow decode + ffprobe `dims > 0`), compares it
+  **perceptually** (difference hash, so a re-encoded/resized copy of the same
+  picture still matches) to each track's embedded art, and embeds the folder image
+  into every track whose art is missing or different, so the whole album matches
+  the cover the media server shows. Invalid folder images are flagged, never
+  propagated. `--scan-only` / `--dry-run` (default) / `--execute`; execute backs up
+  the album first and routes every write through the validated core (ffprobe
+  read-back). Wired into the lifecycle **covers** phase after `generate_folder_art`
+  (repair -> folder.jpg -> sync). New counter `covers_synced`. Added
+  `tests/test_cover_consistency.py` (16 tests). `/verify-covers` remains the AI
+  layer that catches a folder image that is itself the wrong picture.
 
 ### 2026-07-02 (Shared library-walk exclusions + dedupe fingerprint gate)
 - **Canonical directory exclusions**: every walker now shares one rule set in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -876,6 +876,16 @@ if not os.path.exists(kb_path):
 
 ## Changelog
 
+### 2026-07-02 (Off-library album backups)
+- **Album backups now live off-library**: `repair_covers.backup_album` (used by
+  cover-repair and cover-consistency before any track rewrite) no longer creates a
+  sibling `backups/` folder inside each album. Backups are copied to
+  `D:\music_backup\_album_backups\<artist>\<album>\` (`ALBUM_BACKUP_ROOT`), mirroring
+  the album path, so they never clutter the library or get re-scanned. `repair_library`
+  and `cover_consistency.sync_library`/`sync_album` take an injectable `backup_root`
+  (default `ALBUM_BACKUP_ROOT`; tests pass a tmp dir to stay hermetic). Existing
+  in-album `backups/` folders were moved to the off-library store and removed.
+
 ### 2026-07-02 (Cover consistency: folder.jpg <-> embedded parity)
 - **New `utilities/cover_consistency.py` + `cli.py sync-covers`**: the album
   **folder image is authoritative**. For every album with a folder.jpg/cover/front,
@@ -885,8 +895,8 @@ if not os.path.exists(kb_path):
   into every track whose art is missing or different, so the whole album matches
   the cover the media server shows. Invalid folder images are flagged, never
   propagated. `--scan-only` / `--dry-run` (default) / `--execute`; execute backs up
-  the album first and routes every write through the validated core (ffprobe
-  read-back). Wired into the lifecycle **covers** phase after `generate_folder_art`
+  the album **off-library** first (see below) and routes every write through the
+  validated core (ffprobe read-back). Wired into the lifecycle **covers** phase after `generate_folder_art`
   (repair -> folder.jpg -> sync). New counter `covers_synced`. Added
   `tests/test_cover_consistency.py` (16 tests). `/verify-covers` remains the AI
   layer that catches a folder image that is itself the wrong picture.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -875,6 +875,27 @@ if not os.path.exists(kb_path):
 
 ## Changelog
 
+### 2026-07-02 (Shared library-walk exclusions + dedupe fingerprint gate)
+- **Canonical directory exclusions**: every walker now shares one rule set in
+  `utilities/core/audio_file.py` (`EXCLUDED_DIR_NAMES`, `is_excluded_dir`,
+  `is_excluded_path`, `prune_dirs`). NAS recycle bins and OS/system dirs
+  (`.recycle`, `#recycle`, `@eaDir`, `#snapshot`, `$RECYCLE.BIN`, `System Volume
+  Information`, macOS `.Trashes`/`.Spotlight-V100`/`.fseventsd`, Syncthing
+  `.stfolder`/`.stversions`) plus the toolkit's own `backups/`, `.cover_backup/`,
+  `_duplicates/` are pruned from **scan, validate, dedupe, cover-repair, and
+  folder-art** walks. Fixed: the cover phase (`repair_covers.find_album_folders`)
+  was recursing into `\\...\music\.recycle\` and flagging deleted stub tracks as
+  "missing", inflating the missing/flagged counts. Real folders that start with a
+  dot/symbol (`.38 Special`, `...And You Will Know Us...`) are still scanned.
+  `deduplicate.py` and `generate_folder_art.py` dropped their private `EXC` sets
+  and delegate to the shared rules (no more drift). Added
+  `tests/test_scan_filter.py` (7 tests).
+- **Dedupe is fingerprint-authoritative**: a track is a duplicate only when its
+  Chromaprint fingerprint is identical to the keeper (different fp = distinct,
+  no fp = review/never-move). Fixed `_find_fpcalc` to locate the project-root
+  `fpcalc.exe` (it was silently disabled). Whole-library re-scan: 17 heuristic
+  candidates collapsed to 1 genuine fingerprint-verified duplicate.
+
 ### 2026-06-29 (Unified lifecycle + zero-knowledge onboarding)
 - **Unified `lifecycle` command**: `python cli.py lifecycle <path>` (and
   `python -m orchestrator.main lifecycle`) runs every phase in one canonical order

--- a/agents/scanner.py
+++ b/agents/scanner.py
@@ -26,6 +26,10 @@ from mutagen.mp4 import MP4
 
 from .base import BaseAgent
 
+# Shared exclusion rules so the scanner skips the same recycle-bin / system /
+# backup dirs as every other library walker.
+from utilities.core.audio_file import is_excluded_dir
+
 
 @dataclass
 class TrackData:
@@ -235,7 +239,7 @@ class ScannerAgent(BaseAgent):
         albums = []
 
         for item in path.iterdir():
-            if item.is_dir():
+            if item.is_dir() and not is_excluded_dir(item.name):
                 # Check if it contains audio files
                 audio_files = self._find_audio_files(item)
                 if audio_files:
@@ -259,7 +263,7 @@ class ScannerAgent(BaseAgent):
         library = {}
 
         for artist_dir in path.iterdir():
-            if artist_dir.is_dir():
+            if artist_dir.is_dir() and not is_excluded_dir(artist_dir.name):
                 artist_name = artist_dir.name
                 self.log(f"Scanning artist: {artist_name}")
                 albums = self.scan_artist(str(artist_dir))

--- a/cli.py
+++ b/cli.py
@@ -110,6 +110,20 @@ def cmd_repair_covers(args):
         print("(Dry run - no changes made)")
 
 
+def cmd_sync_covers(args):
+    """Reconcile embedded track art with the album folder image (folder.jpg authoritative)."""
+    from utilities.cover_consistency import sync_library, _print_summary
+
+    summary = sync_library(
+        args.path,
+        scan_only=args.scan_only,
+        dry_run=args.dry_run or not (args.scan_only or args.execute),
+        execute=args.execute,
+        log_path=getattr(args, 'log', None),
+    )
+    _print_summary(summary)
+
+
 def cmd_dedupe(args):
     """Find duplicate copies of a track in a folder; move losers to backup."""
     from utilities.deduplicate import deduplicate_library
@@ -229,6 +243,18 @@ def main():
     repair_parser.add_argument('--scan-only', action='store_true', help='Report corrupted albums without making changes')
     repair_parser.add_argument('--dry-run', action='store_true', help='Show the repair plan without fetching or writing')
     repair_parser.set_defaults(func=cmd_repair_covers)
+
+    # sync-covers command (folder image <-> embedded art parity)
+    sync_parser = subparsers.add_parser(
+        'sync-covers',
+        help='Make each track match the album folder image (perceptual; folder.jpg authoritative)')
+    sync_parser.add_argument('path', help='Library / artist / album folder')
+    sync_parser.add_argument('--scan-only', action='store_true', help='report only; never write')
+    sync_parser.add_argument('--dry-run', action='store_true', help='show the plan; write nothing (default)')
+    sync_parser.add_argument('--execute', action='store_true',
+                             help='embed the folder image into mismatched tracks')
+    sync_parser.add_argument('--log', default=None, help='execute-mode log path')
+    sync_parser.set_defaults(func=cmd_sync_covers)
 
     # dedupe command
     dedupe_parser = subparsers.add_parser('dedupe', help='Find duplicate tracks; move losers to backup (never deletes)')

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -20,6 +20,11 @@ from pathlib import Path
 # Import agents
 from agents import ScannerAgent, ValidatorAgent, FixerAgent
 
+# Shared library-walk exclusion rules (recycle bins, system dirs, backups) so the
+# orchestrator's album discovery skips the same non-album folders as every other
+# walker (dedupe, cover-repair, folder-art).
+from utilities.core.audio_file import is_excluded_dir
+
 # Single source of truth for the lifecycle phase order (the parity anchor).
 # Downstream code should import this rather than redefining the order.
 #   from orchestrator.main import LIFECYCLE_PHASES
@@ -116,13 +121,14 @@ def cmd_scan(args):
         # Multiple albums - scan subdirectories
         print("Discovering albums...")
         for item in scan_path.iterdir():
-            if item.is_dir():
+            if item.is_dir() and not is_excluded_dir(item.name):
                 if _has_audio_files(item):
                     albums_to_scan.append(str(item))
                 else:
                     # Check subdirectories (artist/album structure)
                     for subitem in item.iterdir():
-                        if subitem.is_dir() and _has_audio_files(subitem):
+                        if (subitem.is_dir() and not is_excluded_dir(subitem.name)
+                                and _has_audio_files(subitem)):
                             albums_to_scan.append(str(subitem))
 
     print(f"Found {len(albums_to_scan)} albums to scan")
@@ -559,12 +565,13 @@ def _discover_albums(scan_path: Path) -> list:
         albums.append(str(scan_path))
         return albums
     for item in scan_path.iterdir():
-        if item.is_dir():
+        if item.is_dir() and not is_excluded_dir(item.name):
             if _has_audio_files(item):
                 albums.append(str(item))
             else:
                 for subitem in item.iterdir():
-                    if subitem.is_dir() and _has_audio_files(subitem):
+                    if (subitem.is_dir() and not is_excluded_dir(subitem.name)
+                            and _has_audio_files(subitem)):
                         albums.append(str(subitem))
     return albums
 

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -625,7 +625,7 @@ def cmd_lifecycle(args):
     counts = {
         "scanned": 0, "identified": 0, "validated": 0, "needs_review": 0,
         "deduped_moved": 0, "covers_repaired": 0, "folderjpg_added": 0,
-        "fixed": 0, "flagged": 0,
+        "covers_synced": 0, "fixed": 0, "flagged": 0,
     }
 
     # =================== scan ===================
@@ -734,6 +734,17 @@ def cmd_lifecycle(args):
     gfa = generate_folder_art(str(scan_path), execute=execute)
     counts["folderjpg_added"] = gfa.get('written', 0)
     counts["flagged"] += gfa.get('failed', 0)
+    # Folder image <-> embedded art parity: folder.jpg is authoritative, so every
+    # track whose embedded art is missing/different (perceptual) is brought into
+    # line. Runs AFTER generate_folder_art so a folder image exists to propagate.
+    from utilities.cover_consistency import sync_library as _sync_covers
+    cs = _sync_covers(str(scan_path), scan_only=scan_only, dry_run=dry_run, execute=execute)
+    counts["covers_synced"] = int(cs.get('tracks_embedded' if execute else 'tracks_to_embed', 0))
+    counts["flagged"] += int(cs.get('folder_invalid', 0))
+    sverb = "synced" if execute else "would sync"
+    print(f"Cover parity: {cs.get('needs_sync', 0)} albums need sync  |  "
+          f"tracks {sverb}: {counts['covers_synced']}  |  "
+          f"folder image invalid: {cs.get('folder_invalid', 0)}")
 
     # =================== fix ===================
     print("\n--- Phase: fix ---")
@@ -779,6 +790,7 @@ def cmd_lifecycle(args):
     print(f"  Deduped moved:   {counts['deduped_moved']}")
     print(f"  Covers repaired: {counts['covers_repaired']}")
     print(f"  Folder.jpg added:{counts['folderjpg_added']}")
+    print(f"  Covers synced:   {counts['covers_synced']}")
     print(f"  Fixed:           {counts['fixed']}")
     print(f"  Flagged:         {counts['flagged']}")
     if scan_only:

--- a/tests/test_cover_consistency.py
+++ b/tests/test_cover_consistency.py
@@ -141,10 +141,12 @@ def test_check_album_invalid_folder_image(tmp_path):
 @pytest.mark.skipif(not ffprobe_available(), reason="needs bundled ffmpeg")
 def test_sync_album_execute_makes_all_match(tmp_path):
     album = _album(tmp_path, ["A", "B", None], folder_kind="A")
-    res = sync_album(album, execute=True)
+    bk = tmp_path / "backup_store"
+    res = sync_album(album, execute=True, backup_root=bk)
     assert res.embedded == 2 and res.failed == 0
-    # a pristine backup was taken before rewriting
-    assert (album / "backups").is_dir()
+    # a pristine backup was taken OFF-LIBRARY (mirrored <artist>/<album>), never in the album
+    assert (bk / "Artist" / "Album").is_dir()
+    assert not (album / "backups").exists()
     # re-check: whole album now matches the folder image
     assert check_album(album).status == CONSISTENT
 
@@ -152,29 +154,33 @@ def test_sync_album_execute_makes_all_match(tmp_path):
 @pytest.mark.skipif(not ffprobe_available(), reason="needs bundled ffmpeg")
 def test_sync_library_dry_run_writes_nothing(tmp_path):
     album = _album(tmp_path, ["A", "B"], folder_kind="A")
+    bk = tmp_path / "backup_store"
     before = (album / "02 Song 2.mp3").read_bytes()
-    summ = sync_library(tmp_path, dry_run=True)
+    summ = sync_library(tmp_path, dry_run=True, backup_root=bk)
     assert summ["needs_sync"] == 1
     assert summ["tracks_to_embed"] == 1
     assert summ["tracks_embedded"] == 0
-    assert not (album / "backups").exists()
+    assert not bk.exists() and not (album / "backups").exists()
     assert (album / "02 Song 2.mp3").read_bytes() == before   # untouched
 
 
 @pytest.mark.skipif(not ffprobe_available(), reason="needs bundled ffmpeg")
 def test_sync_library_execute_embeds_and_reports(tmp_path):
     _album(tmp_path, ["A", "B", None], folder_kind="A")
-    summ = sync_library(tmp_path, execute=True)
+    bk = tmp_path / "backup_store"
+    summ = sync_library(tmp_path, execute=True, backup_root=bk)
     assert summ["mode"] == "execute"
     assert summ["needs_sync"] == 1
     assert summ["tracks_embedded"] == 2
     assert summ["consistent"] == 0        # it was needs_sync, now fixed
+    assert (bk / "Artist" / "Album").is_dir()   # backup went off-library
 
 
 @pytest.mark.skipif(not ffprobe_available(), reason="needs bundled ffmpeg")
 def test_sync_library_scan_only_never_writes(tmp_path):
     album = _album(tmp_path, ["A", "B"], folder_kind="A")
-    summ = sync_library(tmp_path, scan_only=True, execute=True)  # scan_only wins
+    bk = tmp_path / "backup_store"
+    summ = sync_library(tmp_path, scan_only=True, execute=True, backup_root=bk)  # scan_only wins
     assert summ["mode"] == "scan-only"
     assert summ["tracks_embedded"] == 0
-    assert not (album / "backups").exists()
+    assert not bk.exists() and not (album / "backups").exists()

--- a/tests/test_cover_consistency.py
+++ b/tests/test_cover_consistency.py
@@ -1,0 +1,180 @@
+"""Tests for cover consistency (folder image <-> embedded art parity).
+
+The album folder image is authoritative. Matching is PERCEPTUAL (dHash) so a cover
+that was merely re-encoded/resized still matches, while a genuinely different
+picture does not. Mismatched tracks get the folder image embedded so the whole
+album matches folder.jpg.
+
+Solid-color images have degenerate difference-hashes, so fixtures use gradient
+images (distinct, non-trivial hashes).
+"""
+import io
+
+import pytest
+from PIL import Image
+
+from tests.synth import make_audio
+from utilities.core.ffprobe import ffprobe_available
+from utilities.core import cover_art
+from utilities import cover_consistency as cc
+from utilities.cover_consistency import (
+    dhash, hamming, images_match, find_folder_image, validate_folder_image,
+    check_album, sync_album, sync_library,
+    NO_FOLDER_IMAGE, FOLDER_INVALID, CONSISTENT, NEEDS_SYNC,
+)
+
+
+def gradient_jpeg(kind="A", size=(64, 64)) -> bytes:
+    """Distinct patterned JPEGs so dHash is meaningful (not a flat image)."""
+    img = Image.new("L", size)
+    px = img.load()
+    w, h = size
+    for y in range(h):
+        for x in range(w):
+            if kind == "A":
+                v = int(255 * x / (w - 1))          # horizontal gradient
+            elif kind == "B":
+                v = int(255 * y / (h - 1))          # vertical gradient (very different hash)
+            else:
+                v = (x * 13 + y * 7) % 256          # diagonal-ish pattern
+            px[x, y] = v
+    buf = io.BytesIO()
+    img.convert("RGB").save(buf, "JPEG", quality=90)
+    return buf.getvalue()
+
+
+# ---------------- perceptual hash ----------------
+
+def test_same_picture_reencoded_matches():
+    a = gradient_jpeg("A", (64, 64))
+    a_small = gradient_jpeg("A", (32, 32))          # same picture, different size + re-encode
+    assert images_match(dhash(a), dhash(a_small))   # perceptual match despite byte/size diff
+
+
+def test_different_pictures_do_not_match():
+    a, b = gradient_jpeg("A"), gradient_jpeg("B")
+    assert not images_match(dhash(a), dhash(b))
+    assert hamming(dhash(a), dhash(b)) > cc.MATCH_THRESHOLD
+
+
+def test_images_match_requires_both_present():
+    assert not images_match(None, dhash(gradient_jpeg("A")))
+    assert not images_match(dhash(gradient_jpeg("A")), None)
+
+
+def test_dhash_none_on_garbage():
+    assert dhash(b"not an image") is None
+
+
+# ---------------- folder image discovery + validation ----------------
+
+def test_find_folder_image_prefers_folder_stem(tmp_path):
+    (tmp_path / "cover.jpg").write_bytes(gradient_jpeg("A"))
+    (tmp_path / "folder.jpg").write_bytes(gradient_jpeg("B"))
+    assert find_folder_image(tmp_path).name == "folder.jpg"
+
+
+def test_find_folder_image_none_when_absent(tmp_path):
+    assert find_folder_image(tmp_path) is None
+
+
+def test_validate_folder_image_rejects_garbage():
+    assert validate_folder_image(b"\x00\x01\x02 not an image") is False
+
+
+def test_validate_folder_image_accepts_real_cover():
+    assert validate_folder_image(gradient_jpeg("A")) is True
+
+
+# ---------------- per-album check (needs audio -> ffmpeg) ----------------
+
+def _album(tmp_path, embeds, folder_kind=None):
+    """Build an album: embeds is a list of image-kinds (or None) per track; when
+    folder_kind is set, write that folder.jpg. Returns the album Path."""
+    album = tmp_path / "Artist" / "Album"
+    album.mkdir(parents=True)
+    for i, kind in enumerate(embeds, 1):
+        track = make_audio(album / f"{i:02d} Song {i}.mp3")
+        if kind is not None:
+            cover_art.embed_in_file(track, gradient_jpeg(kind), verify=False)
+    if folder_kind is not None:
+        (album / "folder.jpg").write_bytes(gradient_jpeg(folder_kind))
+    return album
+
+
+@pytest.mark.skipif(not ffprobe_available(), reason="needs bundled ffmpeg")
+def test_check_album_consistent(tmp_path):
+    album = _album(tmp_path, ["A", "A", "A"], folder_kind="A")
+    res = check_album(album)
+    assert res.status == CONSISTENT
+    assert res.total_tracks == 3 and res.mismatches == []
+
+
+@pytest.mark.skipif(not ffprobe_available(), reason="needs bundled ffmpeg")
+def test_check_album_flags_mismatches(tmp_path):
+    # folder=A; track1=A (match), track2=B (different), track3=no art
+    album = _album(tmp_path, ["A", "B", None], folder_kind="A")
+    res = check_album(album)
+    assert res.status == NEEDS_SYNC
+    reasons = {t.name: r for t, r in res.mismatches}
+    assert reasons == {"02 Song 2.mp3": "different", "03 Song 3.mp3": "no_art"}
+
+
+@pytest.mark.skipif(not ffprobe_available(), reason="needs bundled ffmpeg")
+def test_check_album_no_folder_image(tmp_path):
+    album = _album(tmp_path, ["A", "A"], folder_kind=None)
+    assert check_album(album).status == NO_FOLDER_IMAGE
+
+
+@pytest.mark.skipif(not ffprobe_available(), reason="needs bundled ffmpeg")
+def test_check_album_invalid_folder_image(tmp_path):
+    album = _album(tmp_path, ["A", "A"], folder_kind=None)
+    (album / "folder.jpg").write_bytes(b"\x00 not an image \x01")
+    res = check_album(album)
+    assert res.status == FOLDER_INVALID
+    # an invalid folder image is never propagated
+    assert res.embedded == 0
+
+
+# ---------------- execute / dry-run ----------------
+
+@pytest.mark.skipif(not ffprobe_available(), reason="needs bundled ffmpeg")
+def test_sync_album_execute_makes_all_match(tmp_path):
+    album = _album(tmp_path, ["A", "B", None], folder_kind="A")
+    res = sync_album(album, execute=True)
+    assert res.embedded == 2 and res.failed == 0
+    # a pristine backup was taken before rewriting
+    assert (album / "backups").is_dir()
+    # re-check: whole album now matches the folder image
+    assert check_album(album).status == CONSISTENT
+
+
+@pytest.mark.skipif(not ffprobe_available(), reason="needs bundled ffmpeg")
+def test_sync_library_dry_run_writes_nothing(tmp_path):
+    album = _album(tmp_path, ["A", "B"], folder_kind="A")
+    before = (album / "02 Song 2.mp3").read_bytes()
+    summ = sync_library(tmp_path, dry_run=True)
+    assert summ["needs_sync"] == 1
+    assert summ["tracks_to_embed"] == 1
+    assert summ["tracks_embedded"] == 0
+    assert not (album / "backups").exists()
+    assert (album / "02 Song 2.mp3").read_bytes() == before   # untouched
+
+
+@pytest.mark.skipif(not ffprobe_available(), reason="needs bundled ffmpeg")
+def test_sync_library_execute_embeds_and_reports(tmp_path):
+    _album(tmp_path, ["A", "B", None], folder_kind="A")
+    summ = sync_library(tmp_path, execute=True)
+    assert summ["mode"] == "execute"
+    assert summ["needs_sync"] == 1
+    assert summ["tracks_embedded"] == 2
+    assert summ["consistent"] == 0        # it was needs_sync, now fixed
+
+
+@pytest.mark.skipif(not ffprobe_available(), reason="needs bundled ffmpeg")
+def test_sync_library_scan_only_never_writes(tmp_path):
+    album = _album(tmp_path, ["A", "B"], folder_kind="A")
+    summ = sync_library(tmp_path, scan_only=True, execute=True)  # scan_only wins
+    assert summ["mode"] == "scan-only"
+    assert summ["tracks_embedded"] == 0
+    assert not (album / "backups").exists()

--- a/tests/test_repair_covers.py
+++ b/tests/test_repair_covers.py
@@ -92,13 +92,15 @@ def test_repair_with_cover_override_restores_dims(tmp_path):
     _embed_empty_apic(track)
 
     good = make_image_bytes("JPEG", size=(640, 640))
-    summary = repair_covers.repair_library(tmp_path, cover_override=good)
+    bk = tmp_path / "backup_store"
+    summary = repair_covers.repair_library(tmp_path, cover_override=good, backup_root=bk)
 
     assert summary["repaired"] == 1
     assert summary["files_fixed"] == 1
 
-    # Backup was created before modification.
-    assert (tmp_path / "backups" / "track.mp3").exists()
+    # Backup was created OFF-LIBRARY before modification (never a sibling backups/ dir).
+    assert not (tmp_path / "backups").exists()
+    assert list(bk.rglob("track.mp3")), "off-library backup of the track should exist"
 
     # The repaired bytes round-trip and ffprobe now sees real dimensions.
     assert extract_cover_from_file(track) == good

--- a/tests/test_scan_filter.py
+++ b/tests/test_scan_filter.py
@@ -1,0 +1,68 @@
+"""The canonical library-walk exclusion rules (utilities.core.audio_file).
+
+Every walker (scan, validate, dedupe, cover-repair, folder-art) shares these so a
+NAS recycle bin or OS metadata dir can never be mistaken for an album. Real music
+folders that merely *look* odd (leading dots, symbols) must still be scanned.
+"""
+import os
+
+from utilities.core.audio_file import (
+    is_excluded_dir, is_excluded_path, prune_dirs, EXCLUDED_DIR_NAMES,
+)
+
+
+# ---------------- excluded: recycle bins / system / backup dirs ----------------
+
+def test_recycle_and_system_dirs_excluded():
+    for name in [
+        ".recycle", ".Recycle", "#recycle", "@eaDir", "#snapshot",
+        "$RECYCLE.BIN", "System Volume Information", "recycler",
+        ".Trashes", ".Trash-1000", ".Spotlight-V100", ".fseventsd",
+        ".stfolder", ".DS_Store", "lost+found",
+    ]:
+        assert is_excluded_dir(name), name
+
+
+def test_toolkit_own_stores_excluded():
+    for name in ["backups", ".cover_backup", "_duplicates"]:
+        assert is_excluded_dir(name), name
+
+
+# ---------------- NOT excluded: real album / artist folders ----------------
+
+def test_real_music_folders_not_excluded():
+    # Bands/albums that start with a dot or symbol are still legitimate music.
+    for name in [
+        ".38 Special", "...And You Will Know Us by the Trail of Dead",
+        "U2", "Achtung Baby", "Café Tacvba", "Sigur Rós",
+        "Disc 1", "CD2", "Various Artists", "70's Disco Ball Party Pack",
+    ]:
+        assert not is_excluded_dir(name), name
+
+
+# ---------------- path-level pruning ----------------
+
+def test_is_excluded_path_prunes_nested_recycle():
+    root = os.path.join("music")
+    # anything under a .recycle component is excluded, however deep
+    assert is_excluded_path(root, os.path.join("music", ".recycle", "x", "y", "z"))
+    assert is_excluded_path(root, os.path.join("music", "Various Artists", "@eaDir"))
+    # a clean album path is kept
+    assert not is_excluded_path(root, os.path.join("music", "U2", "Achtung Baby"))
+
+
+def test_is_excluded_dir_takes_basename():
+    # Full paths are reduced to their final component before matching.
+    assert is_excluded_dir(os.path.join("music", ".recycle"))
+    assert not is_excluded_dir(os.path.join("music", "Achtung Baby"))
+
+
+def test_prune_dirs_mutates_in_place():
+    dirs = ["U2", ".recycle", "@eaDir", "Achtung Baby", "backups"]
+    prune_dirs(dirs)
+    assert dirs == ["U2", "Achtung Baby"]  # os.walk contract: same list object, filtered
+
+
+def test_excluded_names_are_lowercase():
+    # The set is compared case-insensitively; keep it normalized to avoid misses.
+    assert all(n == n.lower() for n in EXCLUDED_DIR_NAMES)

--- a/utilities/core/audio_file.py
+++ b/utilities/core/audio_file.py
@@ -1,4 +1,11 @@
-"""Shared audio-file helpers: supported formats and iteration."""
+"""Shared audio-file helpers: supported formats, iteration, and the canonical
+directory-exclusion rules used by every library walk.
+
+The exclusion rules live here (the module every walker already imports) so scan,
+validate, dedupe, cover-repair, and folder-art all skip the *same* non-album
+directories - NAS recycle bins, OS/system metadata dirs, and the toolkit's own
+off-library backup stores - and can never drift apart.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +15,50 @@ from typing import Iterator
 
 # Audio containers the toolkit reads/writes cover art for.
 AUDIO_EXTS = {".mp3", ".m4a", ".mp4", ".flac"}
+
+# Directory names that are never a real album folder. Their contents are usually
+# deleted/stub files (recycle bins) or non-music system metadata, so counting them
+# as albums/tracks pollutes every report. Compared case-insensitively.
+EXCLUDED_DIR_NAMES = {
+    ".recycle", "#recycle", "@eadir", "#snapshot",              # Synology / OMV / QNAP NAS
+    "$recycle.bin", "recycler", "system volume information",    # Windows
+    ".trashes", ".trash", ".spotlight-v100", ".fseventsd",      # macOS
+    ".documentrevisions-v100", ".temporaryitems", ".ds_store",
+    ".stfolder", ".stversions",                                 # Syncthing
+    "lost+found", "found.000",
+    "backups", ".cover_backup", "_duplicates",                  # the toolkit's own stores
+}
+
+# Any directory whose (lower-cased) name starts with one of these markers is a
+# NAS/OS system dir - e.g. "@eaDir", "#recycle", "$RECYCLE.BIN", ".Trash-1000".
+# Note: a bare "." prefix is deliberately NOT excluded, so real album/artist
+# folders that legitimately start with a dot (".38 Special", "...And You Will
+# Know Us by the Trail of Dead") are still scanned.
+EXCLUDED_DIR_PREFIXES = ("@", "#", "$", ".trash", ".spotlight", ".fseventsd")
+
+
+def is_excluded_dir(name) -> bool:
+    """True if a single directory *name* is a recycle-bin / system / backup dir
+    that must never be treated as an album folder."""
+    n = os.path.basename(str(name).rstrip("/\\")).strip().lower()
+    return n in EXCLUDED_DIR_NAMES or n.startswith(EXCLUDED_DIR_PREFIXES)
+
+
+def is_excluded_path(root, path) -> bool:
+    """True if any directory component of *path* relative to *root* is excluded,
+    so a walk can prune whole subtrees (e.g. everything under ``.recycle/``)."""
+    root_p, p = Path(root), Path(path)
+    try:
+        parts = p.relative_to(root_p).parts
+    except ValueError:
+        parts = p.parts
+    return any(is_excluded_dir(part) for part in parts)
+
+
+def prune_dirs(dirnames) -> None:
+    """In-place filter of an ``os.walk`` *dirnames* list so the walk never
+    descends into excluded directories. Mutates the list (os.walk contract)."""
+    dirnames[:] = [d for d in dirnames if not is_excluded_dir(d)]
 
 
 def is_audio_file(path) -> bool:

--- a/utilities/cover_consistency.py
+++ b/utilities/cover_consistency.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Cover consistency: make each track's embedded art match the album's folder image.
+
+The album ``folder.jpg`` (or ``cover``/``front``) is treated as the source of
+truth. For every album that has a folder image, this tool:
+
+1. **Validates the folder image** - it must decode (Pillow) and, when ffprobe is
+   available, report real ``dims > 0`` (the same ground truth Jellyfin uses). An
+   invalid folder image is NEVER propagated; the album is flagged instead.
+2. **Compares the folder image to each track's embedded art perceptually** - a
+   difference hash (dHash) so a picture that was merely re-encoded or resized
+   still counts as a match (most ``folder.jpg`` files were generated FROM the
+   embedded art and re-encoded, so their bytes differ but the image is the same).
+3. **Embeds the folder image into every mismatched track** - any track whose
+   embedded art is missing or perceptually different from the folder image is
+   brought into line, so the whole album matches ``folder.jpg``.
+
+Albums with NO folder image are left to ``generate_folder_art`` (which derives one
+from embedded art); this tool only *propagates* an existing, validated folder
+image inward.
+
+Safety (shared three-mode contract):
+  * ``--scan-only``  report only - never reads embedded art beyond hashing, never writes.
+  * ``--dry-run`` (default) - compute the full plan (which tracks would change) but write nothing.
+  * ``--execute`` - the only mode that writes. Before any track in an album is
+    rewritten, every audio file in that album is copied to a sibling ``backups/``
+    folder, and each embed goes through the validated core pipeline
+    (``core.cover_art.embed_in_file``: validate -> write -> ffprobe read-back).
+
+CLI (via ``cli.py``)::
+
+    python cli.py sync-covers "/path/to/music"            # dry-run (default)
+    python cli.py sync-covers "/path/to/music" --scan-only
+    python cli.py sync-covers "/path/to/music" --execute
+"""
+
+from __future__ import annotations
+
+import io
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+# Allow running as a script (python utilities/cover_consistency.py ...).
+if __package__ in (None, ""):
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from PIL import Image
+
+from utilities.core.audio_file import iter_audio_files
+from utilities.core.cover_art import (
+    InvalidCoverArt,
+    embed_in_file,
+    extract_cover_from_file,
+    validate_image,
+)
+from utilities.core.ffprobe import ffprobe_available
+from utilities.generate_folder_art import ffmpeg_image_dims
+from utilities.repair_covers import backup_album, find_album_folders
+
+# Folder-image discovery (mirrors generate_folder_art).
+IMG_EXT = (".jpg", ".jpeg", ".png")
+FOLDER_STEMS = ("folder", "cover", "front")
+
+# dHash size -> 64-bit hash. Two images are "the same picture" when their hashes
+# differ by <= MATCH_THRESHOLD bits. A re-encode/resize of the same art lands
+# around 0-4; genuinely different covers are typically >20, so 8 is comfortably
+# separating without false merges.
+HASH_SIZE = 8
+MATCH_THRESHOLD = 8
+
+LOG_DEFAULT = "outputs/cover_sync.log"
+
+
+# --------------------------------------------------------------------------- #
+# Perceptual hash
+# --------------------------------------------------------------------------- #
+def dhash(data: bytes, hash_size: int = HASH_SIZE) -> Optional[int]:
+    """Difference hash of image *bytes* as a ``hash_size*hash_size``-bit int.
+
+    Robust to re-encoding and scaling (compares relative brightness of adjacent
+    pixels). Returns ``None`` if the bytes cannot be decoded as an image.
+    """
+    try:
+        img = Image.open(io.BytesIO(data)).convert("L").resize(
+            (hash_size + 1, hash_size), Image.LANCZOS
+        )
+    except Exception:
+        return None
+    px = img.load()
+    bits = 0
+    idx = 0
+    for y in range(hash_size):
+        for x in range(hash_size):
+            bits |= (1 if px[x, y] < px[x + 1, y] else 0) << idx
+            idx += 1
+    return bits
+
+
+def hamming(a: int, b: int) -> int:
+    """Number of differing bits between two hashes."""
+    return bin(a ^ b).count("1")
+
+
+def images_match(a: Optional[int], b: Optional[int], threshold: int = MATCH_THRESHOLD) -> bool:
+    """True if two dHashes are within *threshold* bits (both must be present)."""
+    if a is None or b is None:
+        return False
+    return hamming(a, b) <= threshold
+
+
+# --------------------------------------------------------------------------- #
+# Folder image
+# --------------------------------------------------------------------------- #
+def find_folder_image(album_dir) -> Optional[Path]:
+    """Return the album's folder image (folder/cover/front .jpg/.jpeg/.png), or None."""
+    best: Optional[Path] = None
+    for entry in sorted(Path(album_dir).iterdir()):
+        if entry.is_file() and entry.suffix.lower() in IMG_EXT and entry.stem.lower() in FOLDER_STEMS:
+            # Prefer a 'folder' stem, then 'cover', then 'front'.
+            if best is None or FOLDER_STEMS.index(entry.stem.lower()) < FOLDER_STEMS.index(best.stem.lower()):
+                best = entry
+    return best
+
+
+def validate_folder_image(data: bytes) -> bool:
+    """True if the folder image is a real, decodable cover with positive dims.
+
+    Pillow decode + magic bytes via ``validate_image``; when ffprobe is present,
+    also require ffmpeg to read positive dimensions (catches the width=0 case
+    Pillow alone accepts).
+    """
+    try:
+        validate_image(data)
+    except InvalidCoverArt:
+        return False
+    if ffprobe_available():
+        dims = ffmpeg_image_dims(data)
+        if not dims or dims[0] <= 0 or dims[1] <= 0:
+            return False
+    return True
+
+
+# --------------------------------------------------------------------------- #
+# Per-album check
+# --------------------------------------------------------------------------- #
+# status values
+NO_FOLDER_IMAGE = "no_folder_image"   # nothing to propagate (generate_folder_art's job)
+FOLDER_INVALID = "folder_invalid"     # folder image is corrupt/0x0 -> flagged, never propagated
+CONSISTENT = "consistent"             # every track already matches the folder image
+NEEDS_SYNC = "needs_sync"             # >=1 track missing/different -> would embed folder image
+
+
+@dataclass
+class AlbumResult:
+    album: Path
+    status: str
+    folder_image: Optional[Path] = None
+    total_tracks: int = 0
+    mismatches: List[Tuple[Path, str]] = field(default_factory=list)  # (track, 'no_art'|'different')
+    embedded: int = 0
+    failed: int = 0
+    errors: List[str] = field(default_factory=list)
+
+
+def check_album(album_dir) -> AlbumResult:
+    """Diagnose one album's folder<->embedded cover consistency (no writes)."""
+    album = Path(album_dir)
+    folder_img = find_folder_image(album)
+    if folder_img is None:
+        return AlbumResult(album=album, status=NO_FOLDER_IMAGE)
+
+    try:
+        folder_bytes = folder_img.read_bytes()
+    except OSError as exc:
+        return AlbumResult(album=album, status=FOLDER_INVALID, folder_image=folder_img,
+                           errors=[f"read {folder_img.name}: {exc}"])
+
+    if not validate_folder_image(folder_bytes):
+        return AlbumResult(album=album, status=FOLDER_INVALID, folder_image=folder_img,
+                           errors=[f"{folder_img.name}: invalid/unreadable cover"])
+
+    folder_hash = dhash(folder_bytes)
+    result = AlbumResult(album=album, status=CONSISTENT, folder_image=folder_img)
+    for track in iter_audio_files(album):
+        result.total_tracks += 1
+        art = extract_cover_from_file(track)
+        if not art:
+            result.mismatches.append((track, "no_art"))
+            continue
+        if not images_match(folder_hash, dhash(art)):
+            result.mismatches.append((track, "different"))
+    if result.mismatches:
+        result.status = NEEDS_SYNC
+    return result
+
+
+def sync_album(album_dir, *, execute: bool) -> AlbumResult:
+    """Check an album and, in *execute* mode, embed the folder image into every
+    mismatched track (after backing the album up). Returns the result with
+    ``embedded``/``failed`` populated."""
+    result = check_album(album_dir)
+    if result.status != NEEDS_SYNC or not execute:
+        return result
+
+    folder_bytes = result.folder_image.read_bytes()
+    backup_album(result.album)  # pristine copy before any rewrite
+    for track, _reason in result.mismatches:
+        try:
+            embed_in_file(track, folder_bytes)  # validated write + ffprobe read-back
+            result.embedded += 1
+        except Exception as exc:  # fail-soft per file
+            result.failed += 1
+            result.errors.append(f"{track.name}: {exc}")
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Library orchestration
+# --------------------------------------------------------------------------- #
+def sync_library(
+    path,
+    *,
+    scan_only: bool = False,
+    dry_run: bool = False,
+    execute: bool = False,
+    log_path: Optional[str] = None,
+) -> Dict[str, object]:
+    """Walk ``path`` and reconcile embedded art with each album's folder image.
+
+    Exactly one of scan_only / dry_run / execute governs writes; execute is the
+    only mode that modifies audio. Returns a summary dict.
+    """
+    # Resolve mode (execute wins, then scan_only, else dry-run default).
+    do_execute = bool(execute) and not scan_only
+    summary: Dict[str, object] = {
+        "albums": 0,
+        "with_folder_image": 0,
+        "consistent": 0,
+        "needs_sync": 0,
+        "no_folder_image": 0,
+        "folder_invalid": 0,
+        "tracks_to_embed": 0,
+        "tracks_embedded": 0,
+        "tracks_failed": 0,
+        "flagged": [],       # albums needing human attention (folder_invalid)
+        "details": [],       # per-album needs_sync detail
+        "mode": "execute" if do_execute else ("scan-only" if scan_only else "dry-run"),
+    }
+
+    albums = find_album_folders(path)  # shares recycle/system/backup exclusions
+    log_fh = None
+    if do_execute:
+        lp = Path(log_path or LOG_DEFAULT)
+        lp.parent.mkdir(parents=True, exist_ok=True)
+        log_fh = open(lp, "a", encoding="utf-8")
+
+    try:
+        for album in albums:
+            summary["albums"] = int(summary["albums"]) + 1
+            res = sync_album(album, execute=do_execute)
+
+            if res.status == NO_FOLDER_IMAGE:
+                summary["no_folder_image"] = int(summary["no_folder_image"]) + 1
+                continue
+            summary["with_folder_image"] = int(summary["with_folder_image"]) + 1
+
+            if res.status == FOLDER_INVALID:
+                summary["folder_invalid"] = int(summary["folder_invalid"]) + 1
+                summary["flagged"].append({"album": str(res.album), "errors": res.errors})  # type: ignore[attr-defined]
+                continue
+            if res.status == CONSISTENT:
+                summary["consistent"] = int(summary["consistent"]) + 1
+                continue
+
+            # NEEDS_SYNC
+            summary["needs_sync"] = int(summary["needs_sync"]) + 1
+            summary["tracks_to_embed"] = int(summary["tracks_to_embed"]) + len(res.mismatches)
+            summary["tracks_embedded"] = int(summary["tracks_embedded"]) + res.embedded
+            summary["tracks_failed"] = int(summary["tracks_failed"]) + res.failed
+            summary["details"].append({  # type: ignore[attr-defined]
+                "album": str(res.album),
+                "folder_image": res.folder_image.name if res.folder_image else None,
+                "mismatched": [(t.name, r) for t, r in res.mismatches],
+                "embedded": res.embedded,
+                "failed": res.failed,
+            })
+            if log_fh and res.embedded:
+                for track, reason in res.mismatches:
+                    log_fh.write(f"{album}\t{track.name}\t{reason}\tembedded_folder_image\n")
+    finally:
+        if log_fh:
+            log_fh.close()
+
+    return summary
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _print_summary(summary: Dict[str, object]) -> None:
+    print("\n=== Cover Consistency Summary ===")
+    print(f"Mode:                 {summary['mode']}")
+    print(f"Albums scanned:       {summary['albums']}")
+    print(f"  with folder image:  {summary['with_folder_image']}")
+    print(f"  consistent:         {summary['consistent']}")
+    print(f"  need sync:          {summary['needs_sync']}")
+    print(f"  no folder image:    {summary['no_folder_image']} (handled by folder-art step)")
+    print(f"  folder image bad:   {summary['folder_invalid']} (flagged, NOT propagated)")
+    verb = "embedded" if summary["mode"] == "execute" else "would embed"
+    print(f"Tracks {verb}: {summary['tracks_to_embed']}"
+          + (f"  (ok {summary['tracks_embedded']}, failed {summary['tracks_failed']})"
+             if summary["mode"] == "execute" else ""))
+    flagged = summary.get("flagged") or []
+    if flagged:
+        print(f"\nFLAGGED - folder image invalid ({len(flagged)}):")
+        for f in flagged[:25]:
+            print(f"  {f['album']}")
+    if summary["mode"] != "execute":
+        print("(no changes made)")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Reconcile embedded track art with the album folder image "
+                    "(folder.jpg authoritative; perceptual match; write into mismatched tracks).")
+    parser.add_argument("path", help="Library / artist / album folder")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--scan-only", action="store_true", help="Report only; never write")
+    mode.add_argument("--dry-run", action="store_true", help="Show the plan; write nothing (default)")
+    mode.add_argument("--execute", action="store_true", help="Embed folder image into mismatched tracks")
+    parser.add_argument("--log", default=None, help=f"Execute-mode log path (default {LOG_DEFAULT})")
+    args = parser.parse_args(argv)
+
+    summary = sync_library(
+        args.path,
+        scan_only=args.scan_only,
+        dry_run=args.dry_run or not (args.scan_only or args.execute),
+        execute=args.execute,
+        log_path=args.log,
+    )
+    _print_summary(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utilities/cover_consistency.py
+++ b/utilities/cover_consistency.py
@@ -23,8 +23,9 @@ Safety (shared three-mode contract):
   * ``--scan-only``  report only - never reads embedded art beyond hashing, never writes.
   * ``--dry-run`` (default) - compute the full plan (which tracks would change) but write nothing.
   * ``--execute`` - the only mode that writes. Before any track in an album is
-    rewritten, every audio file in that album is copied to a sibling ``backups/``
-    folder, and each embed goes through the validated core pipeline
+    rewritten, every audio file in that album is copied OFF-LIBRARY to
+    ``D:\\music_backup\\_album_backups\\<artist>\\<album>\\`` (never inside the
+    album), and each embed goes through the validated core pipeline
     (``core.cover_art.embed_in_file``: validate -> write -> ffprobe read-back).
 
 CLI (via ``cli.py``)::
@@ -198,16 +199,16 @@ def check_album(album_dir) -> AlbumResult:
     return result
 
 
-def sync_album(album_dir, *, execute: bool) -> AlbumResult:
+def sync_album(album_dir, *, execute: bool, backup_root=None) -> AlbumResult:
     """Check an album and, in *execute* mode, embed the folder image into every
-    mismatched track (after backing the album up). Returns the result with
-    ``embedded``/``failed`` populated."""
+    mismatched track (after backing the album up OFF-LIBRARY). Returns the result
+    with ``embedded``/``failed`` populated."""
     result = check_album(album_dir)
     if result.status != NEEDS_SYNC or not execute:
         return result
 
     folder_bytes = result.folder_image.read_bytes()
-    backup_album(result.album)  # pristine copy before any rewrite
+    backup_album(result.album, backup_root=backup_root)  # off-library copy before any rewrite
     for track, _reason in result.mismatches:
         try:
             embed_in_file(track, folder_bytes)  # validated write + ffprobe read-back
@@ -228,6 +229,7 @@ def sync_library(
     dry_run: bool = False,
     execute: bool = False,
     log_path: Optional[str] = None,
+    backup_root=None,
 ) -> Dict[str, object]:
     """Walk ``path`` and reconcile embedded art with each album's folder image.
 
@@ -261,7 +263,7 @@ def sync_library(
     try:
         for album in albums:
             summary["albums"] = int(summary["albums"]) + 1
-            res = sync_album(album, execute=do_execute)
+            res = sync_album(album, execute=do_execute, backup_root=backup_root)
 
             if res.status == NO_FOLDER_IMAGE:
                 summary["no_folder_image"] = int(summary["no_folder_image"]) + 1

--- a/utilities/deduplicate.py
+++ b/utilities/deduplicate.py
@@ -53,11 +53,15 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from mutagen import File as MutagenFile  # noqa: E402
 
-from utilities.core.audio_file import AUDIO_EXTS, iter_audio_files  # noqa: E402
+from utilities.core.audio_file import (  # noqa: E402
+    AUDIO_EXTS, iter_audio_files, EXCLUDED_DIR_NAMES, is_excluded_path,
+)
 from utilities.core.cover_art import extract_cover_from_file  # noqa: E402
 from utilities.core.naming import transliterate  # noqa: E402
 
-EXC = {'.recycle', '@eadir', '#recycle', 'backups', '.cover_backup', '_duplicates'}
+# Kept as a module-level name for back-compat; the canonical set + rules live in
+# utilities.core.audio_file so every walker shares one definition.
+EXC = EXCLUDED_DIR_NAMES
 
 STRONG_SECONDS = 3.0
 PROBABLE_SECONDS = 10.0
@@ -142,8 +146,7 @@ class Summary:
 
 
 def _excluded(root: Path, p: Path) -> bool:
-    return any(x.lower() in EXC or x.startswith(('.', '@', '#'))
-               for x in p.relative_to(root).parts)
+    return is_excluded_path(root, p)
 
 
 def normalize_for_match(text: str, aggressive: bool = False) -> str:

--- a/utilities/extract_metadata.py
+++ b/utilities/extract_metadata.py
@@ -9,6 +9,10 @@ import json
 import csv
 import sys
 
+# Allow running as a script (python utilities/extract_metadata.py ...).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from utilities.core.audio_file import prune_dirs
+
 def get_cover_art_info(filepath):
     """Extract cover art information from audio file"""
     try:
@@ -118,6 +122,7 @@ def scan_directory(base_path):
     results = []
 
     for root, dirs, files in os.walk(base_path):
+        prune_dirs(dirs)  # skip recycle-bin / system / backup dirs
         for file in files:
             ext = os.path.splitext(file)[1].lower()
             if ext in audio_extensions:

--- a/utilities/generate_folder_art.py
+++ b/utilities/generate_folder_art.py
@@ -48,9 +48,12 @@ from utilities.core.cover_art import (  # noqa: E402
     InvalidCoverArt,
 )
 from utilities.core.ffprobe import attached_pic_dims, ffprobe_available  # noqa: E402
-from utilities.core.audio_file import AUDIO_EXTS  # noqa: E402
+from utilities.core.audio_file import (  # noqa: E402
+    AUDIO_EXTS, EXCLUDED_DIR_NAMES, is_excluded_path,
+)
 
-EXC = {'.recycle', '@eadir', '#recycle', 'backups', '.cover_backup'}
+# Back-compat alias; canonical set + rules live in utilities.core.audio_file.
+EXC = EXCLUDED_DIR_NAMES
 IMG_EXT = {'.jpg', '.jpeg', '.png'}
 FOLDER_STEMS = ('folder', 'cover', 'front')
 
@@ -60,10 +63,7 @@ class _Skip(Exception):
 
 
 def excluded(root: Path, p: Path) -> bool:
-    return any(
-        x.lower() in EXC or x.startswith(('.', '@', '#'))
-        for x in p.relative_to(root).parts
-    )
+    return is_excluded_path(root, p)
 
 
 def has_folder_image(d: Path) -> bool:

--- a/utilities/repair_covers.py
+++ b/utilities/repair_covers.py
@@ -45,7 +45,7 @@ if __package__ in (None, ""):
 
 from mutagen import File as MutagenFile
 
-from utilities.core.audio_file import is_audio_file, iter_audio_files
+from utilities.core.audio_file import is_audio_file, iter_audio_files, prune_dirs
 from utilities.core.cover_art import (
     InvalidCoverArt,
     download_cover,
@@ -122,9 +122,10 @@ def diagnose_album(album_dir) -> Dict[str, object]:
 def find_album_folders(root) -> List[Path]:
     """Return every folder under ``root`` that directly contains audio files.
 
-    ``root`` itself is included when it holds audio files. The ``backups/``
-    folders this tool creates are skipped so re-runs do not treat them as
-    albums.
+    ``root`` itself is included when it holds audio files. Recycle-bin, system,
+    and backup directories (including the ``backups/`` folders this tool creates)
+    are pruned via the shared exclusion rules so re-runs never treat their
+    (often deleted) contents as albums.
     """
     root_path = Path(root)
     folders: List[Path] = []
@@ -132,8 +133,9 @@ def find_album_folders(root) -> List[Path]:
         return folders
 
     for dirpath, dirnames, filenames in os.walk(root_path):
-        # Prune backup folders from the walk so we never descend into them.
-        dirnames[:] = [d for d in dirnames if d != BACKUP_DIRNAME]
+        # Prune recycle-bin / system / backup folders so we never descend into
+        # them (BACKUP_DIRNAME == "backups" is covered by the shared rules).
+        prune_dirs(dirnames)
         if Path(dirpath).name == BACKUP_DIRNAME:
             continue
         if any(is_audio_file(name) for name in filenames):

--- a/utilities/repair_covers.py
+++ b/utilities/repair_covers.py
@@ -17,7 +17,8 @@ or the bytes fail to decode.
 
 Safety:
   * MANDATORY backup - before any track in an album is rewritten, every audio
-    file in that album is copied to a sibling ``backups/`` folder.
+    file in that album is copied OFF-LIBRARY to
+    ``D:\\music_backup\\_album_backups\\<artist>\\<album>\\`` (never inside the album).
   * Every embed goes through ``core.cover_art`` (validated, hard-fail per file,
     fail-soft per album). Bytes are never embedded without validation.
   * Graceful - rate limits, missing API keys, and "no result" leave files
@@ -55,8 +56,14 @@ from utilities.core.cover_art import (
 )
 from utilities.core.ffprobe import attached_pic_dims, ffprobe_available
 
-# Directory (created inside each album) that holds pre-modification backups.
+# Legacy in-album backup dir name (still pruned from walks for back-compat with any
+# old backups/ folders that may still exist in the library).
 BACKUP_DIRNAME = "backups"
+
+# OFF-LIBRARY root for pre-modification album backups. Backups are stored here,
+# never inside the album, so they don't clutter the library or get re-scanned.
+# Each album is mirrored as <root>/<artist>/<album>/.
+ALBUM_BACKUP_ROOT = Path(r"D:\music_backup\_album_backups")
 
 # Per-file diagnosis results.
 STATUS_OK = "ok"
@@ -252,18 +259,25 @@ def fetch_validated_cover(
 # --------------------------------------------------------------------------- #
 # Backup
 # --------------------------------------------------------------------------- #
-def backup_album(album_dir) -> Optional[Path]:
-    """Copy every audio file in ``album_dir`` to a sibling ``backups/`` folder.
+def backup_album(album_dir, *, backup_root=None) -> Optional[Path]:
+    """Copy every audio file in ``album_dir`` to an OFF-LIBRARY backup folder.
 
-    Existing backups are never overwritten (the first backup is the pristine
-    one). Returns the backup folder, or ``None`` if there is nothing to back up.
+    The backup mirrors the album's ``<artist>/<album>`` path under ``backup_root``
+    (default :data:`ALBUM_BACKUP_ROOT`, i.e. ``D:\\music_backup\\_album_backups``)
+    so backups live outside the music library and never get re-scanned. Existing
+    backups are never overwritten (the first backup is the pristine one). Returns
+    the backup folder, or ``None`` if there is nothing to back up.
     """
-    files = list(iter_audio_files(album_dir))
+    album = Path(album_dir)
+    files = list(iter_audio_files(album))
     if not files:
         return None
 
-    backup_dir = Path(album_dir) / BACKUP_DIRNAME
-    backup_dir.mkdir(exist_ok=True)
+    root = Path(backup_root) if backup_root else ALBUM_BACKUP_ROOT
+    # Mirror the last two path components (artist/album) so the backup is
+    # browsable and traceable without needing to know the library root.
+    backup_dir = root.joinpath(*album.parts[-2:])
+    backup_dir.mkdir(parents=True, exist_ok=True)
     for audio_file in files:
         dest = backup_dir / audio_file.name
         if not dest.exists():
@@ -280,6 +294,7 @@ def repair_library(
     scan_only: bool = False,
     dry_run: bool = False,
     cover_override: Optional[bytes] = None,
+    backup_root=None,
 ) -> Dict[str, object]:
     """Scan ``path`` for corrupted album art and repair what needs repairing.
 
@@ -290,6 +305,8 @@ def repair_library(
         cover_override: Validated image bytes to embed instead of fetching from
             the network. Used for offline testing of the re-embed path; still
             validated by the core pipeline before any write.
+        backup_root: Off-library root for pre-modification backups (default
+            :data:`ALBUM_BACKUP_ROOT`). Injected in tests to stay hermetic.
 
     Returns a summary dict:
         ``{albums, needs_repair, repaired, failed, skipped, files_fixed, details}``
@@ -372,8 +389,8 @@ def repair_library(
             summary["details"].append(detail)  # type: ignore[attr-defined]
             continue
 
-        # MANDATORY backup before any write.
-        backup_dir = backup_album(album_dir)
+        # MANDATORY backup before any write (off-library).
+        backup_dir = backup_album(album_dir, backup_root=backup_root)
         if backup_dir is not None:
             print(f"  backed up tracks to: {backup_dir}")
 


### PR DESCRIPTION
## Summary

Three related fixes to the library-walk and cover pipeline, discovered while running the read-only lifecycle over the full library.

### 1. Centralized library-walk exclusions (`.recycle` and friends)
The cover phase (`repair_covers.find_album_folders`) was recursing into the NAS recycle bin (`\...\music\.recycle\`) and flagging deleted stub tracks as "missing", inflating every report (the phantom "27 covers to repair" were all recycle ghosts). Exclusion logic was also duplicated and inconsistent across walkers.

- One canonical rule set in `utilities/core/audio_file.py` (`EXCLUDED_DIR_NAMES`, `is_excluded_dir`, `is_excluded_path`, `prune_dirs`), shared by **scan, validate, dedupe, cover-repair, folder-art, and extract-metadata**.
- Excludes NAS/OS/system dirs (`.recycle`, `#recycle`, `@eaDir`, `#snapshot`, `$RECYCLE.BIN`, `System Volume Information`, macOS `.Trashes`/`.Spotlight-V100`/`.fseventsd`, Syncthing `.stfolder`/`.stversions`) and the toolkit's own `backups/`, `.cover_backup/`, `_duplicates/`.
- Deliberately keeps real leading-dot music folders (`.38 Special`, `...And You Will Know Us...`).
- `deduplicate.py` and `generate_folder_art.py` dropped their private `EXC` sets and delegate to the shared rules (no more drift).

### 2. `sync-covers`: folder.jpg ↔ embedded-art parity
New `utilities/cover_consistency.py` + `python cli.py sync-covers`. The album **folder image is authoritative**: validate it (Pillow decode + ffprobe `dims>0`), compare it **perceptually** (difference hash, so a re-encoded/resized copy of the same picture still matches), and embed the folder image into every track whose art is missing or different, so the whole album matches the cover the media server shows.

- Perceptual match avoids false positives from re-encoding (an exact-byte check would re-embed nearly everything).
- Invalid folder images are flagged, never propagated.
- `--scan-only` / `--dry-run` (default) / `--execute`; wired into the lifecycle **covers** phase after `generate_folder_art` (repair → folder.jpg → sync). New `covers_synced` counter.
- `/verify-covers` remains the AI layer that catches a folder image that is itself the *wrong* picture.

### 3. Album backups moved off-library
`repair_covers.backup_album` (used by cover-repair and cover-consistency before any track rewrite) no longer creates a sibling `backups/` folder inside each album. Backups now go to `D:\music_backup\_album_backups\<artist>\<album>\` (`ALBUM_BACKUP_ROOT`), mirroring the album path so they never clutter the library or get re-scanned. `repair_library` / `sync_library` / `sync_album` take an injectable `backup_root` (tests use a tmp dir to stay hermetic).

## Verification
- `python -m pytest tests/ -q` → **177 passed** (new `test_scan_filter.py` +7, `test_cover_consistency.py` +16; updated repair/lifecycle tests).
- Whole-library read-only pass after the change: **1,623 / 1,623 albums cover-consistent**, 100% folder-image coverage, 0 corrupt/invalid folder images, 0 width=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)